### PR TITLE
Remove old location of notebook from examples

### DIFF
--- a/examples/table_of_contents_examples.js
+++ b/examples/table_of_contents_examples.js
@@ -21,7 +21,6 @@ Gallery.contents = {
     "generalized_linear_models/GLM-robust-with-outlier-detection": "(Generalized) Linear and Hierarchical Linear Models",
     "generalized_linear_models/GLM-robust": "(Generalized) Linear and Hierarchical Linear Models",
     "generalized_linear_models/GLM-rolling-regression": "(Generalized) Linear and Hierarchical Linear Models",
-    "generalized_linear_models/GLM-hierarchical-advi-minibatch": "(Generalized) Linear and Hierarchical Linear Models",
     "gaussian_processes/GP-Kron": "Gaussian Processes",
     "gaussian_processes/GP-Latent": "Gaussian Processes",
     "gaussian_processes/GP-Marginal": "Gaussian Processes",


### PR DESCRIPTION
`GLM-hierarchical-advi-minibatch` appears twice in the table of contents, both in
```
generalized_linear_models/GLM-hierarchical-advi-minibatch
```
and in 
```
variational_inference/GLM-hierarchical-advi-minibatch
```

The latter is correct.

Eventually, there should probably be a CI job in PyMC3 which builds the docs and would catch this kind of error (which prevents the docs from being built)