### PR TITLE
 Update push branch name to main

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   pre-commit:


### PR DESCRIPTION
# Description
Change the default branch name from conventional `master` name to `main`
Closes #15

## Background
The precommit.yml file original had default branch `master`. However, since the change of Github's default branch to term `main` and this new repo, the file hence has to be updated.