### PR TITLE
Replacing PyMC3 plots w/ Arviz plots & sigma Param change [Part 1]

### DIFF
--- a/examples/case_studies/disaster_model.py
+++ b/examples/case_studies/disaster_model.py
@@ -152,4 +152,4 @@ with pm.Model() as model:
     start = {"early_mean": 2.0, "late_mean": 3.0}
 
     tr = pm.sample(1000, tune=500, start=start)
-    pm.plot_trace(tr)
+    az.plot_trace(tr)

--- a/examples/case_studies/disaster_model.py
+++ b/examples/case_studies/disaster_model.py
@@ -151,5 +151,5 @@ with pm.Model() as model:
     # Initial values for stochastic nodes
     start = {"early_mean": 2.0, "late_mean": 3.0}
 
-    tr = pm.sample(1000, tune=500, start=start)
+    tr = pm.sample(1000, tune=500, start=start, cores=1)
     az.plot_trace(tr)

--- a/examples/case_studies/disaster_model.py
+++ b/examples/case_studies/disaster_model.py
@@ -8,7 +8,7 @@ disasters[t] ~ Poi(early_mean if t <= switchpoint, late_mean otherwise)
 
 """
 
-
+import arviz as az
 import theano.tensor as tt
 
 from numpy import arange, array
@@ -152,4 +152,4 @@ with pm.Model() as model:
     start = {"early_mean": 2.0, "late_mean": 3.0}
 
     tr = pm.sample(1000, tune=500, start=start)
-    pm.traceplot(tr)
+    pm.plot_trace(tr)

--- a/examples/case_studies/disaster_model_theano_op.py
+++ b/examples/case_studies/disaster_model_theano_op.py
@@ -4,7 +4,7 @@ deterministics which are not not working with Theano.
 Note that gradient based samplers will not work.
 """
 
-
+import arviz as az
 import theano.tensor as tt
 
 from numpy import arange, array, empty
@@ -166,4 +166,4 @@ with pm.Model() as model:
     start = {"early_mean": 2.0, "late_mean": 3.0}
 
     tr = pm.sample(1000, tune=500, start=start, step=[step1, step2], cores=2)
-    pm.traceplot(tr)
+    az.plot_trace(tr)

--- a/examples/case_studies/disaster_model_theano_op.py
+++ b/examples/case_studies/disaster_model_theano_op.py
@@ -165,5 +165,5 @@ with pm.Model() as model:
     # Initial values for stochastic nodes
     start = {"early_mean": 2.0, "late_mean": 3.0}
 
-    tr = pm.sample(1000, tune=500, start=start, step=[step1, step2], cores=2)
+    tr = pm.sample(1000, tune=500, start=start, step=[step1, step2], cores=1)
     az.plot_trace(tr)

--- a/examples/case_studies/garch_example.py
+++ b/examples/case_studies/garch_example.py
@@ -1,7 +1,8 @@
 import numpy as np
 import theano.tensor as tt
 
-from pymc3 import Model, Normal, Uniform, sample, summary
+from arviz import summary
+from pymc3 import Model, Normal, Uniform, sample
 
 """
 Example from Stan - slightly altered

--- a/examples/case_studies/gelman_schools.py
+++ b/examples/case_studies/gelman_schools.py
@@ -1,6 +1,7 @@
 import numpy as np
 
-from pymc3 import HalfCauchy, Model, Normal, loo, sample
+from arviz import loo
+from pymc3 import HalfCauchy, Model, Normal, sample
 
 """Original Stan model
 

--- a/examples/case_studies/lightspeed_example.py
+++ b/examples/case_studies/lightspeed_example.py
@@ -1,5 +1,5 @@
 import numpy as np
-
+import arviz as az
 import pymc3 as pm
 
 light_speed = np.array(
@@ -92,7 +92,7 @@ def run(n=5000):
     with model_1:
         trace = pm.sample(n)
 
-        pm.summary(trace)
+        az.summary(trace)
 
 
 if __name__ == "__main__":

--- a/examples/pymc3_howto/LKJ_correlation.py
+++ b/examples/pymc3_howto/LKJ_correlation.py
@@ -54,7 +54,7 @@ def run(n=1000):
     with model:
         trace = pm.sample(n)
     az.plot_trace(
-        trace, var_names=["mu", "r"], lines={"mu": mu_r, "r": corr_r[np.triu_indices(n_var, k=1)]}
+        trace, var_names=["mu", "r"]
     )
 
 

--- a/examples/pymc3_howto/LKJ_correlation.py
+++ b/examples/pymc3_howto/LKJ_correlation.py
@@ -54,7 +54,7 @@ def run(n=1000):
     with model:
         trace = pm.sample(n)
     az.plot_trace(
-        trace, varnames=["mu", "r"], lines={"mu": mu_r, "r": corr_r[np.triu_indices(n_var, k=1)]}
+        trace, var_names=["mu", "r"], lines={"mu": mu_r, "r": corr_r[np.triu_indices(n_var, k=1)]}
     )
 
 

--- a/examples/pymc3_howto/LKJ_correlation.py
+++ b/examples/pymc3_howto/LKJ_correlation.py
@@ -1,6 +1,6 @@
 import numpy as np
 import theano.tensor as tt
-
+import arviz as az
 from numpy.random import multivariate_normal
 
 import pymc3 as pm
@@ -53,7 +53,7 @@ def run(n=1000):
         n = 50
     with model:
         trace = pm.sample(n)
-    pm.traceplot(
+    az.plot_trace(
         trace, varnames=["mu", "r"], lines={"mu": mu_r, "r": corr_r[np.triu_indices(n_var, k=1)]}
     )
 

--- a/examples/pymc3_howto/rankdata_ordered.py
+++ b/examples/pymc3_howto/rankdata_ordered.py
@@ -46,14 +46,14 @@ def run(n=1500):
     with m:
         trace = pm.sample(n)
 
-    pm.traceplot(trace, varnames=["mu_hat"])
+    az.plot_trace(trace, varnames=["mu_hat"])
 
     print("Example observed data: ")
     print(y[:30, :].T)
     print("The true ranking is: ")
     print(yreal.flatten())
     print("The Latent mean is: ")
-    latentmu = np.hstack(([0], pm.summary(trace, varnames=["mu_hat"])["mean"].values))
+    latentmu = np.hstack(([0], az.summary(trace, varnames=["mu_hat"])["mean"].values))
     print(np.round(latentmu, 2))
     print("The estimated ranking is: ")
     print(np.argsort(latentmu))

--- a/examples/pymc3_howto/rankdata_ordered.py
+++ b/examples/pymc3_howto/rankdata_ordered.py
@@ -1,3 +1,4 @@
+import arviz as az
 import numpy as np
 import theano.tensor as tt
 

--- a/examples/pymc3_howto/rankdata_ordered.py
+++ b/examples/pymc3_howto/rankdata_ordered.py
@@ -46,14 +46,14 @@ def run(n=1500):
     with m:
         trace = pm.sample(n)
 
-    az.plot_trace(trace, varnames=["mu_hat"])
+    az.plot_trace(trace, var_names=["mu_hat"])
 
     print("Example observed data: ")
     print(y[:30, :].T)
     print("The true ranking is: ")
     print(yreal.flatten())
     print("The Latent mean is: ")
-    latentmu = np.hstack(([0], az.summary(trace, varnames=["mu_hat"])["mean"].values))
+    latentmu = np.hstack(([0], az.summary(trace, var_names=["mu_hat"])["mean"].values))
     print(np.round(latentmu, 2))
     print("The estimated ranking is: ")
     print(np.argsort(latentmu))

--- a/examples/samplers/samplers_mvnormal.py
+++ b/examples/samplers/samplers_mvnormal.py
@@ -9,6 +9,7 @@ normalized effective sampling rates.
 
 import time
 
+import arviz as az
 import numpy as np
 import pandas as pd
 import theano.tensor as tt
@@ -50,7 +51,7 @@ def run(steppers, p):
             runtimes[name] = time.time() - t_start
             print("{} samples across {} chains".format(len(mt) * mt.nchains, mt.nchains))
             traces[name] = mt
-            en = pm.ess(mt)
+            en = az.ess(mt)
             print(f"effective: {en}\r\n")
             if USE_XY:
                 effn[name] = np.mean(en["x"]) / len(mt) / mt.nchains

--- a/examples/samplers/samplers_mvnormal.py
+++ b/examples/samplers/samplers_mvnormal.py
@@ -47,7 +47,7 @@ def run(steppers, p):
         for step_cls in steppers:
             name = step_cls.__name__
             t_start = time.time()
-            mt = pm.sample(draws=10000, chains=16, parallelize=False, step=step_cls(), start=start)
+            mt = pm.sample(draws=10000, chains=16, step=step_cls(), start=start)
             runtimes[name] = time.time() - t_start
             print("{} samples across {} chains".format(len(mt) * mt.nchains, mt.nchains))
             traces[name] = mt
@@ -75,9 +75,9 @@ if __name__ == "__main__":
     for p in df_effectiven.index:
         trace, rate, runtime = run(methods, p)
         for name in names:
-            df_effectiven.set_value(p, name, rate[name])
-            df_runtime.set_value(p, name, runtime[name])
-            df_performance.set_value(p, name, rate[name] / runtime[name])
+            df_effectiven.at[p, name] = rate[name]
+            df_runtime.at[p, name] = runtime[name]
+            df_performance.at[p, name] =  rate[name] / runtime[name]
 
     print("\r\nEffective sample size [0...1]")
     print(df_effectiven.T.to_string(float_format="{:.3f}".format))

--- a/examples/time_series/arma_example.py
+++ b/examples/time_series/arma_example.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from theano import scan, shared
 
+import arviz as az
 import pymc3 as pm
 
 """
@@ -82,8 +83,8 @@ def run(n_samples=1000):
     with model:
         trace = pm.sample(draws=n_samples, tune=1000, target_accept=0.99)
 
-    pm.plots.traceplot(trace)
-    pm.plots.forestplot(trace)
+    az.plot_trace(trace)
+    az.plot_forest(trace)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description
The following is a large PR breakdown of PR #16.

Replace PyMC3 dependent plots with arviz plots in case studies & examples.
* The issue is a 3-part step for the following:
  * Initiative via Issue https://github.com/pymc-devs/pymc3/issues/4371 (Leave open)

Replace parameter `sd` with `sigma` (e.g. some examples have `pm.Normal(...sd=...)`
* Closes issue #2