### PR TITLE
Fix typo in normalizing flow overview notebook

### DIFF
--- a/examples/variational_inference/normalizing_flows_overview.ipynb
+++ b/examples/variational_inference/normalizing_flows_overview.ipynb
@@ -71,8 +71,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Formulae can be composed as a string, e.g. `'scale-loc'`,
-`'scale-hh*4-loc'`, `'planar*10'`. Each step is separated with `'-'`, and repeated flows are defined with `'*'` in the form of `'<flow>*<#repeats>'`.\n",
+    "Formulae can be composed as a string, e.g. `'scale-loc'`, `'scale-hh*4-loc'`, `'planar*10'`. Each step is separated with `'-'`, and repeated flows are defined with `'*'` in the form of `'<flow>*<#repeats>'`.\n",
     "\n",
     "Flow-based approximations in PyMC3 are based on the `NormalizingFlow` class, with corresponding inference classes named using the `NF` abbreviation (analogous to how `ADVI` and `SVGD` are treated in PyMC3).\n",
     "\n",

--- a/examples/variational_inference/normalizing_flows_overview.ipynb
+++ b/examples/variational_inference/normalizing_flows_overview.ipynb
@@ -71,7 +71,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Formulae can be composed as a string, e.g. `'scale-loc'`, `'scale-hh*4-loc'`, `'panar*10'`. Each step is separated with `'-'`, and repeated flows are defined with `'*'` in the form of `'<flow>*<#repeats>'`.\n",
+    "Formulae can be composed as a string, e.g. `'scale-loc'`,
+`'scale-hh*4-loc'`, `'planar*10'`. Each step is separated with `'-'`, and repeated flows are defined with `'*'` in the form of `'<flow>*<#repeats>'`.\n",
     "\n",
     "Flow-based approximations in PyMC3 are based on the `NormalizingFlow` class, with corresponding inference classes named using the `NF` abbreviation (analogous to how `ADVI` and `SVGD` are treated in PyMC3).\n",
     "\n",


### PR DESCRIPTION
## Description
<!-- Thank you so much for your PR!

To help us review your contribution, please provide the info requested below. Otherwise,
we may leave reviews that are actually out of the scope of the current PR. -->

Fixes a typo in  [https://docs.pymc.io/pymc-examples/examples/variational_inference/normalizing_flows_overview.html](Normalizing flow notebook), (panar -> planar)
 <!-- Tracker column: General Updates, ArviZ, Best Practices -->

<!-- We understand that PRs can sometimes be overwhelming, especially as the reviews start coming in.
Please let us know if the reviews are unclear or the recommended next step seems overly demanding,
if you would like help in addressing a reviewer's comments,
or if you have been waiting too long to hear back on your PR.

Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/arviz/blob/main/CODE_OF_CONDUCT.md -->
