### PR TITLE
Warn users about obsolete instructions.

### DIFF
--- a/examples/getting_started.ipynb
+++ b/examples/getting_started.ipynb
@@ -31,6 +31,11 @@
    "source": [
     "## Installation\n",
     "\n",
+    "----\n",
+    "**Note:** These instructions are out of date, and no longer correct. Please see the [Installation instructions](https://github.com/pymc-devs/pymc3#Installation) on the [GitHub site for PyMC3](https://github.com/pymc-devs/pymc3).\n",
+    "\n",
+    "----\n",
+    "\n",
     "Running PyMC3 requires a working Python interpreter, either version 2.7 (or more recent) or 3.5 (or more recent); we recommend that new users install version 3.5. A complete Python installation for Mac OSX, Linux and Windows can most easily be obtained by downloading and installing the free [`Anaconda Python Distribution`](https://store.continuum.io/cshop/anaconda/) by ContinuumIO. \n",
     "\n",
     "`PyMC3` can be installed using [\"pip\"](https://pip.pypa.io/en/latest/installing.html):\n",


### PR DESCRIPTION
Installation instructions in "Getting Started" are no longer correct.

## Description

This PR adds a warning note block to the installation instructions in the Getting Started notebook. Trying to maintain installation instructions in multiple places is error-prone, so I modified this just to point to the installation instructions on the GitHub homepage.

I simply tagged the installation instructions with a warning block instead of removing them, because that was more drastic.
