### PR TITLE
Simpson paradox example notebook

### DIFF
--- a/examples/table_of_contents_examples.js
+++ b/examples/table_of_contents_examples.js
@@ -26,6 +26,7 @@ Gallery.contents = {
     "generalized_linear_models/GLM-robust": "(Generalized) Linear and Hierarchical Linear Models",
     "generalized_linear_models/GLM-rolling-regression": "(Generalized) Linear and Hierarchical Linear Models",
     "generalized_linear_models/GLM-truncated-censored-regression": "(Generalized) Linear and Hierarchical Linear Models",
+    "generalized_linear_models/GLM-simpsons-paradox": "(Generalized) Linear and Hierarchical Linear Models",
     "gaussian_processes/GP-Kron": "Gaussian Processes",
     "gaussian_processes/GP-Latent": "Gaussian Processes",
     "gaussian_processes/GP-Marginal": "Gaussian Processes",


### PR DESCRIPTION
Hi. Here is a new notebook. There are already linear regression and hierarchical regression notebooks, but I think this one adds: a) a focus on Simpson's paradox (which is a popular and widely searched term), b) does a reasonable job of showing best practice, eg in `coords`, `xarray`, posterior predictions vs posterior predictive _distributions_, etc.

I'm very happy to get any feedback on the points below, or any other points in fact:
1. Am I right in thinking Model 1, 2, and 3 are presented by this notation? 1) `y ~ 1 + x`, 2) `y ~ 0 + (1 + x | group)`, 3) `y ~ 1 + x + (1 + x | group)` I'm not 100% convinced by the last one.
2. Referring to the 3-panel plots, what is the best language to use here? Posterior predictive vs posterior predictive _distribution_?
3. Should I add a more robust case for why the hierarchical model (model 3) is worth doing here or just refer to other sources?
4. Do you think it lacks a satisfactory conclusion, or is it fine as it is?
5. If anyone knows how to satisfy the `arviz` warnings then I'd be happy to hear. 
6. This is currently in `examples > GLM`, but let me know if you think it's better placed in `examples > Case Studies`
7. I believe I've used `coords` and `xarray` properly, but these are both still a little new to me, so I'm open to any simplifications/corrections.