### PR TITLE
Convert plots in Spline example to matplotlib

### DIFF
--- a/examples/splines/spline.ipynb
+++ b/examples/splines/spline.ipynb
@@ -1474,6 +1474,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Authors\n",
+    "\n",
     "- Authored by Joshua Cook in October, 2021\n",
     "- Updated by [Tyler James Burch](https://github.com/tjburch) in October, 2021"
    ]


### PR DESCRIPTION
I noticed in the (very well done!) spline example from @jhrcook added in #232 that plots were not in Matplotlib, but following the PR it seemed the preference was for matplotlib for ease of maintenance over time. I went ahead and converted the figures to matplotlib. 

Aside from the matplotlib changes, the lowess and knot-based lm portions had to be implemented in `statsmodels` before plotting, since those aren't available directly in mpl.

Tracking issue: #234 