### PR TITLE
remove codeautolink temporarly

### DIFF
--- a/examples/conf.py
+++ b/examples/conf.py
@@ -19,7 +19,7 @@ extensions = [
     "sphinxext.opengraph",
     "sphinx_copybutton",
     "sphinxcontrib.bibtex",
-    "sphinx_codeautolink",
+    # "sphinx_codeautolink",
 ]
 
 # List of patterns, relative to source directory, that match files and


### PR DESCRIPTION
This should fix the docs build while we investigate why codeautolink is failing
