### PR TITLE
allow retrieving doi code from rtd

### DIFF
--- a/examples/conf.py
+++ b/examples/conf.py
@@ -118,11 +118,24 @@ fontawesome_included = True
 
 # MyST config
 myst_enable_extensions = ["colon_fence", "deflist", "dollarmath", "amsmath", "substitution"]
+citation_code = f"""
+```bibtex
+@incollection{{citekey,
+  author    = "<notebook authors, see above>"
+  title     = "<notebook title>",
+  editor    = "PyMC Team",
+  booktitle = "PyMC examples",
+  doi       = "{doi_code}"
+}}
+```
+"""
+
+
 myst_substitutions = {
     "pip_dependencies": "{{ extra_dependencies }}",
     "conda_dependencies": "{{ extra_dependencies }}",
     "extra_install_notes": "",
-    "doi_code": doi_code,
+    "citation_code": citation_code,
 }
 jupyter_execute_notebooks = "off"
 

--- a/examples/conf.py
+++ b/examples/conf.py
@@ -71,7 +71,8 @@ html_theme_options = {
     "page_sidebar_items": ["postcard", "page-toc", "edit-this-page"],
 }
 version = os.environ.get("READTHEDOCS_VERSION", "")
-version = version if "-" in version else "main"
+version = version if "." in version else "main"
+doi_code = os.environ.get("READTHEDOCS_DOI", "10.5281/zenodo.5654871")
 html_context = {
     "github_url": "https://github.com",
     "github_user": "pymc-devs",
@@ -79,8 +80,8 @@ html_context = {
     "github_version": version,
     "doc_path": "examples/",
     "sandbox_repo": f"pymc-devs/pymc-sandbox/{version}",
-    "doi_url": "https://doi.org/10.5281/zenodo.5654871",
-    "doi_code": "10.5281/zenodo.5654871",
+    "doi_url": f"https://doi.org/{doi_code}",
+    "doi_code": doi_code,
 }
 
 
@@ -121,6 +122,7 @@ myst_substitutions = {
     "pip_dependencies": "{{ extra_dependencies }}",
     "conda_dependencies": "{{ extra_dependencies }}",
     "extra_install_notes": "",
+    "doi_code": doi_code,
 }
 jupyter_execute_notebooks = "off"
 

--- a/examples/conf.py
+++ b/examples/conf.py
@@ -72,7 +72,7 @@ html_theme_options = {
 }
 version = os.environ.get("READTHEDOCS_VERSION", "")
 version = version if "." in version else "main"
-doi_code = os.environ.get("READTHEDOCS_DOI", "10.5281/zenodo.5654871")
+doi_code = os.environ.get("DOI_READTHEDOCS", "10.5281/zenodo.5654871")
 html_context = {
     "github_url": "https://github.com",
     "github_user": "pymc-devs",

--- a/examples/page_footer.md
+++ b/examples/page_footer.md
@@ -17,15 +17,7 @@ Also remember to cite the relevant libraries used by your code.
 
 Here is an citation template in bibtex:
 
-```bibtex
-@incollection{citekey,
-  author    = "<notebook authors, see above>"
-  title     = "<notebook title>",
-  editor    = "PyMC Team",
-  booktitle = "PyMC examples",
-  doi       = "10.5281/zenodo.5654871"
-}
-```
+{{ citation_code }}
 
 which once rendered could look like:
 


### PR DESCRIPTION
For now manual process, but with this we can release, wait for zenodo to generate the doi, enter it as env variable at readthedocs and rebuild the docs for the snapshot. This will show the version specific doi in the snapshots