### PR TITLE
try setting up pre-commit hook for bibtex

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,7 @@ or if you have been waiting too long to hear back on your PR. -->
 
 + [ ] Notebook follows style guide https://docs.pymc.io/en/latest/contributing/jupyter_style.html
 + [ ] PR description contains a link to the relevant issue: a tracker one for existing notebooks or a proposal one for new notebooks
++ [ ] Check the notebook is not excluded from any pre-commit check: https://github.com/pymc-devs/pymc-examples/blob/main/.pre-commit-config.yaml
 
 
 ### Helpful links

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,4 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '15'
     - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,12 @@ repos:
             |examples/variational_inference/convolutional_vae_keras_advi\.ipynb$
             |examples/pymc3_howto/sampling_callback\.ipynb$
             |examples/gaussian_processes/GP-Latent\.ipynb$
+- repo: https://github.com/FlamingTempura/bibtex-tidy
+  rev: v1.8.5
+  hooks:
+    - id: bibtex-tidy
+      files: examples/references.bib
+      args: ["--sort=author,year,title"]
 - repo: local
   hooks:
     - id: watermark

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,18 +15,32 @@ repos:
   rev: 0.3.0
   hooks:
     - id: check-execution-order
+      args: [--strict]
       exclude: |
             (?x)^
-            ^examples/samplers/DEMetropolisZ_EfficiencyComparison\.ipynb$
-            |examples/variational_inference/convolutional_vae_keras_advi\.ipynb$
-            |examples/pymc3_howto/sampling_callback\.ipynb$
+            ^examples/ode_models/ODE_with_manual_gradients\.ipynb$
+            |examples/samplers/DEMetropolisZ_EfficiencyComparison\.ipynb$
             |examples/gaussian_processes/GP-Latent\.ipynb$
+            |examples/gaussian_processes/GP-MaunaLoa2\.ipynb$
+            |examples/samplers/MLDA_gravity_surveying\.ipynb$
+            |examples/case_studies/putting_workflow\.ipynb$
+            |examples/pymc3_howto/sampling_callback\.ipynb$
+            |examples/case_studies/blackbox_external_likelihood\.ipynb$
+            |examples/samplers/GLM-hierarchical-jax\.ipynb$
+            |examples/variational_inference/convolutional_vae_keras_advi\.ipynb$
+            |examples/gaussian_processes/GP-TProcess\.ipynb$
+            |examples/mixture_models/dependent_density_regression\.ipynb$
+            |examples/gaussian_processes/GP-Heteroskedastic\.ipynb$
+            |examples/gaussian_processes/GP-MeansAndCovs\.ipynb$
+            |examples/samplers/MLDA_variance_reduction_linear_regression\.ipynb$
+
 - repo: https://github.com/FlamingTempura/bibtex-tidy
   rev: v1.8.5
   hooks:
     - id: bibtex-tidy
       files: examples/references.bib
-      args: ["--sort=author,year,title"]
+      args: ["--sort=key", --quiet]
+      language_version: 15.14.0
 - repo: local
   hooks:
     - id: watermark

--- a/examples/references.bib
+++ b/examples/references.bib
@@ -1,28 +1,3 @@
-@inproceedings{vanderplas2012astroML,
-  author        = {{Vanderplas}, J.T. and {Connolly}, A.J. and {Ivezi{\'c}}, {\v Z}. and {Gray}, A.},
-  booktitle     = {Conference on Intelligent Data Understanding (CIDU)},
-  title         = {Introduction to astroML: Machine learning for astrophysics},
-  month         = {oct.},
-  pages         = {47--54},
-  doi           = {10.1109/CIDU.2012.6382200},
-  year          = {2012}
-}
-@book{ivezić2014astroMLtext,
-  author        = {\v{Z}eljko Ivezi\'{c} and Andrew J. Connolly and Jacob T. VanderPlas and Alexander Gray},
-  doi           = {10.1515/9781400848911},
-  title         = {Statistics, Data Mining, and Machine Learning in Astronomy: A Practical Python Guide for the Analysis of Survey Data},
-  year          = {2014},
-  publisher     = {Princeton University Press},
-  isbn          = {9781400848911}
-}
-@misc{kucukelbir2015automatic,
-  title         = {Automatic Variational Inference in Stan},
-  author        = {Alp Kucukelbir and Rajesh Ranganath and Andrew Gelman and David M. Blei},
-  year          = {2015},
-  eprint        = {1506.03431},
-  archiveprefix = {arXiv},
-  primaryclass  = {stat.ML}
-}
 @article{ando2007bayesian,
   title         = {Bayesian predictive information criterion for the evaluation of hierarchical Bayesian and empirical Bayes models},
   author        = {Ando, Tomohiro},
@@ -47,60 +22,6 @@
   year          = {2016},
   publisher     = {Technical report. Retrieved from https://mc-stan. org/users/docum entat ion~\ldots{}}
 }
-@misc{szegedy2014going,
-  title         = {Going Deeper with Convolutions},
-  author        = {Christian Szegedy and Wei Liu and Yangqing Jia and Pierre Sermanet and Scott Reed and Dragomir Anguelov and Dumitru Erhan and Vincent Vanhoucke and Andrew Rabinovich},
-  year          = {2014},
-  eprint        = {1409.4842},
-  archiveprefix = {arXiv},
-  primaryclass  = {cs.CV}
-}
-@book{molnar2019,
-  title         = {Interpretable Machine Learning},
-  author        = {Christoph Molnar},
-  year          = {2019},
-  subtitle      = {A Guide for Making Black Box Models Explainable},
-  url           = {https://christophm.github.io/interpretable-ml-book/},
-  publisher     = {Christoph Molnar}
-}
-@article{silver2016masteringgo,
-  title         = {Mastering the game of Go with deep neural networks and tree search},
-  author        = {D. Silver, A. Huang, C. Maddison et al.},
-  journal       = {Nature},
-  volume        = {529},
-  pages         = {484--489},
-  year          = {2016},
-  url           = {https://doi.org/10.1038/nature16961}
-}
-@misc{hogg2010data,
-  title         = {Data analysis recipes: Fitting a model to data},
-  author        = {David W. Hogg and Jo Bovy and Dustin Lang},
-  year          = {2010},
-  eprint        = {1008.4686},
-  archiveprefix = {arXiv},
-  primaryclass  = {astro-ph.IM}
-}
-@misc{kingma2014autoencoding,
-  title         = {Auto-Encoding Variational Bayes},
-  author        = {Diederik P Kingma and Max Welling},
-  year          = {2014},
-  eprint        = {1312.6114},
-  archiveprefix = {arXiv},
-  primaryclass  = {stat.ML}
-}
-@article{johnson1999,
-  doi           = {10.2307/3802789},
-  url           = {https://doi.org/10.2307/3802789},
-  year          = {1999},
-  month         = jul,
-  publisher     = {{JSTOR}},
-  volume        = {63},
-  number        = {3},
-  pages         = {763},
-  author        = {Douglas H. Johnson},
-  title         = {The Insignificance of Statistical Significance Testing},
-  journal       = {The Journal of Wildlife Management}
-}
 @article{efron1975data,
   title         = {Data analysis using Stein's estimator and its generalizations},
   author        = {Efron, Bradley and Morris, Carl},
@@ -110,18 +31,6 @@
   pages         = {311--319},
   year          = {1975},
   publisher     = {Taylor \& Francis}
-}
-@book{gelman2013bayesian,
-  title         = {Bayesian Data Analysis},
-  publisher     = {Chapman and Hall/CRC},
-  author        = {Gelman, Andrew and Carlin, John B. and Stern, Hal S. and Dunson, David B. and Vehtari, Aki and Rubin, Donald B.},
-  year          = {2013}
-}
-@book{gelman2020regression,
-  title         = {Regression and other stories},
-  author        = {Gelman, Andrew and Hill, Jennifer and Vehtari, Aki},
-  year          = {2020},
-  publisher     = {Cambridge University Press}
 }
 @book{gelman2006data,
   title         = {Data analysis using regression and multilevel/hierarchical models},
@@ -150,6 +59,39 @@
   publisher     = {Wiley Online Library},
   doi           = {10.1002/sim.3107}
 }
+@book{gelman2013bayesian,
+  title         = {Bayesian Data Analysis},
+  publisher     = {Chapman and Hall/CRC},
+  author        = {Gelman, Andrew and Carlin, John B. and Stern, Hal S. and Dunson, David B. and Vehtari, Aki and Rubin, Donald B.},
+  year          = {2013}
+}
+@book{gelman2020regression,
+  title         = {Regression and other stories},
+  author        = {Gelman, Andrew and Hill, Jennifer and Vehtari, Aki},
+  year          = {2020},
+  publisher     = {Cambridge University Press}
+}
+@article{goldberg2001eigentaste,
+  author        = {Ken Goldberg and Theresa Roeder and Chris Perkins},
+  title         = {Eigentaste: A Constant Time Collaborative Filtering Algorithm},
+  journal       = {Information Retrieval},
+  year          = {2001},
+  volume        = {4},
+  pages         = {133--151}
+}
+@article{goodman1999,
+  doi           = {10.7326/0003-4819-130-12-199906150-00008},
+  url           = {https://doi.org/10.7326/0003-4819-130-12-199906150-00008},
+  year          = {1999},
+  month         = jun,
+  publisher     = {American College of Physicians},
+  volume        = {130},
+  number        = {12},
+  pages         = {995},
+  author        = {Steven N. Goodman},
+  title         = {Toward Evidence-Based Medical Statistics. 1: The P Value Fallacy},
+  journal       = {Annals of Internal Medicine}
+}
 @misc{harper2015movielens,
   title         = {The MovieLens Datasets: History and Context},
   author        = {Harper, F. Maxwell and Konstan, Joseph A.},
@@ -161,6 +103,22 @@
   month         = {January},
   url           = {https://doi.org/10.1145/2827872}
 }
+@misc{hogg2010data,
+  title         = {Data analysis recipes: Fitting a model to data},
+  author        = {David W. Hogg and Jo Bovy and Dustin Lang},
+  year          = {2010},
+  eprint        = {1008.4686},
+  archiveprefix = {arXiv},
+  primaryclass  = {astro-ph.IM}
+}
+@book{ivezić2014astroMLtext,
+  author        = {\v{Z}eljko Ivezi\'{c} and Andrew J. Connolly and Jacob T. VanderPlas and Alexander Gray},
+  doi           = {10.1515/9781400848911},
+  title         = {Statistics, Data Mining, and Machine Learning in Astronomy: A Practical Python Guide for the Analysis of Survey Data},
+  year          = {2014},
+  publisher     = {Princeton University Press},
+  isbn          = {9781400848911}
+}
 @book{james2021statisticallearning,
   title         = {An Introduction to Statistical Learning},
   author        = {James, Gareth ad Witten, Daniela and Hastie, Trevor and Tibshirani, Robert},
@@ -169,6 +127,37 @@
   doi           = {https://doi.org/10.1007/978-1-0716-1418-1},
   issn          = {1431-875X},
   isbn          = {978-1-0716-1420-4}
+}
+@article{johnson1999,
+  doi           = {10.2307/3802789},
+  url           = {https://doi.org/10.2307/3802789},
+  year          = {1999},
+  month         = jul,
+  publisher     = {{JSTOR}},
+  volume        = {63},
+  number        = {3},
+  pages         = {763},
+  author        = {Douglas H. Johnson},
+  title         = {The Insignificance of Statistical Significance Testing},
+  journal       = {The Journal of Wildlife Management}
+}
+@misc{kingma2014autoencoding,
+  title         = {Auto-Encoding Variational Bayes},
+  author        = {Diederik P Kingma and Max Welling},
+  year          = {2014},
+  eprint        = {1312.6114},
+  archiveprefix = {arXiv},
+  primaryclass  = {stat.ML}
+}
+@article{koren2009matrixfactorization,
+  author        = {Koren, Yehuda and Bell, Robert and Volinsky, Chris},
+  journal       = {Computer},
+  title         = {Matrix Factorization Techniques for Recommender Systems},
+  year          = {2009},
+  volume        = {42},
+  number        = {8},
+  pages         = {30--37},
+  doi           = {10.1109/MC.2009.263}
 }
 @article{kruschke2013,
   doi           = {10.1037/a0029146},
@@ -182,23 +171,13 @@
   title         = {Bayesian estimation supersedes the t test.},
   journal       = {Journal of Experimental Psychology: General}
 }
-@article{goldberg2001eigentaste,
-  author        = {Ken Goldberg and Theresa Roeder and Chris Perkins},
-  title         = {Eigentaste: A Constant Time Collaborative Filtering Algorithm},
-  journal       = {Information Retrieval},
-  year          = {2001},
-  volume        = {4},
-  pages         = {133--151}
-}
-@article{koren2009matrixfactorization,
-  author        = {Koren, Yehuda and Bell, Robert and Volinsky, Chris},
-  journal       = {Computer},
-  title         = {Matrix Factorization Techniques for Recommender Systems},
-  year          = {2009},
-  volume        = {42},
-  number        = {8},
-  pages         = {30--37},
-  doi           = {10.1109/MC.2009.263}
+@misc{kucukelbir2015automatic,
+  title         = {Automatic Variational Inference in Stan},
+  author        = {Alp Kucukelbir and Rajesh Ranganath and Andrew Gelman and David M. Blei},
+  year          = {2015},
+  eprint        = {1506.03431},
+  archiveprefix = {arXiv},
+  primaryclass  = {stat.ML}
 }
 @article{lewandowski2009generating,
   title         = {Generating random correlation matrices based on vines and extended onion method},
@@ -210,18 +189,18 @@
   year          = {2009},
   publisher     = {Elsevier}
 }
+@book{martin2018bayesian,
+  title         = {Bayesian analysis with Python: introduction to statistical modeling and probabilistic programming using PyMC3 and ArviZ},
+  author        = {Martin, Osvaldo},
+  year          = {2018},
+  publisher     = {Packt Publishing Ltd}
+}
 @book{martin2021bayesian,
   title         = {Bayesian Modeling and Computation in Python},
   author        = {Martin, Osvaldo A and Kumar, Ravin and Lao, Junpeng},
   year          = {2021},
   publisher     = {Chapman and Hall/CRC},
   doi           = {10.1201/9781003019169}
-}
-@book{martin2018bayesian,
-  title         = {Bayesian analysis with Python: introduction to statistical modeling and probabilistic programming using PyMC3 and ArviZ},
-  author        = {Martin, Osvaldo},
-  year          = {2018},
-  publisher     = {Packt Publishing Ltd}
 }
 @book{mcelreath2018statistical,
   title         = {Statistical rethinking: A Bayesian course with examples in R and Stan},
@@ -238,6 +217,22 @@
   url           = {https://proceedings.neurips.cc/paper/2007/file/d7322ed717dedf1eb4e6e52a37ea7bcd-Paper.pdf},
   volume        = {20},
   year          = {2008}
+}
+@misc{mnih2013playing,
+  title         = {Playing Atari with Deep Reinforcement Learning},
+  author        = {Volodymyr Mnih and Koray Kavukcuoglu and David Silver and Alex Graves and Ioannis Antonoglou and Daan Wierstra and Martin Riedmiller},
+  year          = {2013},
+  eprint        = {1312.5602},
+  archiveprefix = {arXiv},
+  primaryclass  = {cs.LG}
+}
+@book{molnar2019,
+  title         = {Interpretable Machine Learning},
+  author        = {Christoph Molnar},
+  year          = {2019},
+  subtitle      = {A Guide for Making Black Box Models Explainable},
+  url           = {https://christophm.github.io/interpretable-ml-book/},
+  publisher     = {Christoph Molnar}
 }
 @article{nowlan1992simplifying,
   title         = {Simplifying Neural Networks By Soft Weight-Sharing},
@@ -257,26 +252,31 @@
   year          = {2008},
   volume        = {25}
 }
-@article{goodman1999,
-  doi           = {10.7326/0003-4819-130-12-199906150-00008},
-  url           = {https://doi.org/10.7326/0003-4819-130-12-199906150-00008},
-  year          = {1999},
-  month         = jun,
-  publisher     = {American College of Physicians},
-  volume        = {130},
-  number        = {12},
-  pages         = {995},
-  author        = {Steven N. Goodman},
-  title         = {Toward Evidence-Based Medical Statistics. 1: The P Value Fallacy},
-  journal       = {Annals of Internal Medicine}
+@article{silver2016masteringgo,
+  title         = {Mastering the game of Go with deep neural networks and tree search},
+  author        = {D. Silver, A. Huang, C. Maddison et al.},
+  journal       = {Nature},
+  volume        = {529},
+  pages         = {484--489},
+  year          = {2016},
+  url           = {https://doi.org/10.1038/nature16961}
 }
-@misc{mnih2013playing,
-  title         = {Playing Atari with Deep Reinforcement Learning},
-  author        = {Volodymyr Mnih and Koray Kavukcuoglu and David Silver and Alex Graves and Ioannis Antonoglou and Daan Wierstra and Martin Riedmiller},
-  year          = {2013},
-  eprint        = {1312.5602},
+@misc{szegedy2014going,
+  title         = {Going Deeper with Convolutions},
+  author        = {Christian Szegedy and Wei Liu and Yangqing Jia and Pierre Sermanet and Scott Reed and Dragomir Anguelov and Dumitru Erhan and Vincent Vanhoucke and Andrew Rabinovich},
+  year          = {2014},
+  eprint        = {1409.4842},
   archiveprefix = {arXiv},
-  primaryclass  = {cs.LG}
+  primaryclass  = {cs.CV}
+}
+@inproceedings{vanderplas2012astroML,
+  author        = {{Vanderplas}, J.T. and {Connolly}, A.J. and {Ivezi{\'c}}, {\v Z}. and {Gray}, A.},
+  booktitle     = {Conference on Intelligent Data Understanding (CIDU)},
+  title         = {Introduction to astroML: Machine learning for astrophysics},
+  month         = {oct.},
+  pages         = {47--54},
+  doi           = {10.1109/CIDU.2012.6382200},
+  year          = {2012}
 }
 @book{wilkinson2005grammar,
   title         = {The Grammar of Graphics},

--- a/examples/references.bib
+++ b/examples/references.bib
@@ -1,326 +1,289 @@
-@article{ando2007bayesian,
-  title={Bayesian predictive information criterion for the evaluation of hierarchical Bayesian and empirical Bayes models},
-  author={Ando, Tomohiro},
-  journal={Biometrika},
-  volume={94},
-  number={2},
-  pages={443--458},
-  year={2007},
-  publisher={Oxford University Press},
-  doi={10.1093/biomet/asm017}
+@inproceedings{vanderplas2012astroML,
+  author        = {{Vanderplas}, J.T. and {Connolly}, A.J. and {Ivezi{\'c}}, {\v Z}. and {Gray}, A.},
+  booktitle     = {Conference on Intelligent Data Understanding (CIDU)},
+  title         = {Introduction to astroML: Machine learning for astrophysics},
+  month         = {oct.},
+  pages         = {47--54},
+  doi           = {10.1109/CIDU.2012.6382200},
+  year          = {2012}
 }
-
-@book{breen1996regression,
-  title={Regression models: Censored, sample selected, or truncated data},
-  author={Breen, Richard and others},
-  volume={111},
-  year={1996},
-  publisher={Sage}
-}
-
-@misc{carpenter2016hierarchical,
-  title={Hierarchical partial pooling for repeated binary trials},
-  author={Carpenter, Bob and Gabry, J and Goodrich, B},
-  year={2016},
-  publisher={Technical report. Retrieved from https://mc-stan. org/users/docum entat ion~…}
-}
-
-@article{efron1975data,
-  title={Data analysis using Stein's estimator and its generalizations},
-  author={Efron, Bradley and Morris, Carl},
-  journal={Journal of the American Statistical Association},
-  volume={70},
-  number={350},
-  pages={311--319},
-  year={1975},
-  publisher={Taylor \& Francis}
-}
-
-@book{gelman2006data,
-  title={Data analysis using regression and multilevel/hierarchical models},
-  author={Gelman, Andrew and Hill, Jennifer},
-  year={2006},
-  publisher={Cambridge university press}
-}
-
-@article{gelman2006multilevel,
-  title={Multilevel (hierarchical) modeling: what it can and cannot do},
-  author={Gelman, Andrew},
-  journal={Technometrics},
-  volume={48},
-  number={3},
-  pages={432--435},
-  year={2006},
-  publisher={Taylor \& Francis}
-}
-
-@article{gelman2008scaling,
-  title={Scaling regression inputs by dividing by two standard deviations},
-  author={Gelman, Andrew},
-  journal={Statistics in medicine},
-  volume={27},
-  number={15},
-  pages={2865--2873},
-  year={2008},
-  publisher={Wiley Online Library},
-  doi={10.1002/sim.3107}
-}
-
-@book{gelman2013bayesian,
-  title={Bayesian Data Analysis},
-  publisher={Chapman and Hall/CRC},
-  author={Gelman, Andrew and Carlin, John B. and Stern, Hal S. and Dunson, David B. and Vehtari, Aki and Rubin, Donald B.},
-  year={2013}
-}
-
-@book{gelman2020regression,
-  title={Regression and other stories},
-  author={Gelman, Andrew and Hill, Jennifer and Vehtari, Aki},
-  year={2020},
-  publisher={Cambridge University Press}
-}
-
-@article{goldberg2001eigentaste,
-    author = {Ken Goldberg and Theresa Roeder and Chris Perkins},
-    title = {Eigentaste: A Constant Time Collaborative Filtering Algorithm},
-    journal = {Information Retrieval},
-    year = {2001},
-    volume = {4},
-    pages = {133--151}
-}
-
-@article{goodman1999,
-  doi = {10.7326/0003-4819-130-12-199906150-00008},
-  url = {https://doi.org/10.7326/0003-4819-130-12-199906150-00008},
-  year = {1999},
-  month = jun,
-  publisher = {American College of Physicians},
-  volume = {130},
-  number = {12},
-  pages = {995},
-  author = {Steven N. Goodman},
-  title = {Toward Evidence-Based Medical Statistics. 1: The P Value Fallacy},
-  journal = {Annals of Internal Medicine}
-}
-
-@misc{harper2015movielens,
-  title={The MovieLens Datasets: History and Context},
-  author={Harper, F. Maxwell and Konstan, Joseph A.},
-  journal={ACM Transactions on Interactive Intelligent Systems},
-  volumne={5},
-  number={4},
-  pages={1--19},
-  year={2016},
-  month={January},
-  url={https://doi.org/10.1145/2827872}
-}
-
-@misc{hogg2010data,
-      title={Data analysis recipes: Fitting a model to data},
-      author={David W. Hogg and Jo Bovy and Dustin Lang},
-      year={2010},
-      eprint={1008.4686},
-      archivePrefix={arXiv},
-      primaryClass={astro-ph.IM}
-}
-
 @book{ivezić2014astroMLtext,
-  author = {Željko Ivezić and Andrew J. Connolly and Jacob T. VanderPlas and Alexander Gray},
-  doi = {10.1515/9781400848911},
-  title = {Statistics, Data Mining, and Machine Learning in Astronomy: A Practical Python Guide for the Analysis of Survey Data},
-  year = {2014},
-  publisher = {Princeton University Press},
-  ISBN = {9781400848911}
+  author        = {\v{Z}eljko Ivezi\'{c} and Andrew J. Connolly and Jacob T. VanderPlas and Alexander Gray},
+  doi           = {10.1515/9781400848911},
+  title         = {Statistics, Data Mining, and Machine Learning in Astronomy: A Practical Python Guide for the Analysis of Survey Data},
+  year          = {2014},
+  publisher     = {Princeton University Press},
+  isbn          = {9781400848911}
 }
-
-@book{james2021statisticallearning,
-  title={An Introduction to Statistical Learning},
-  author={James, Gareth ad Witten, Daniela and Hastie, Trevor and Tibshirani, Robert},
-  year={2021},
-  publisher={Springer},
-  doi={https://doi.org/10.1007/978-1-0716-1418-1},
-  issn={1431-875X},
-  isbn={978-1-0716-1420-4}
-}
-
-@article{johnson1999,
-  doi = {10.2307/3802789},
-  url = {https://doi.org/10.2307/3802789},
-  year = {1999},
-  month = jul,
-  publisher = {{JSTOR}},
-  volume = {63},
-  number = {3},
-  pages = {763},
-  author = {Douglas H. Johnson},
-  title = {The Insignificance of Statistical Significance Testing},
-  journal = {The Journal of Wildlife Management}
-}
-
-@article{koren2009matrixfactorization,
-  author={Koren, Yehuda and Bell, Robert and Volinsky, Chris},
-  journal={Computer},
-  title={Matrix Factorization Techniques for Recommender Systems},
-  year={2009},
-  volume={42},
-  number={8},
-  pages={30--37},
-  doi={10.1109/MC.2009.263}
-}
-
-@misc{kingma2014autoencoding,
-  title={Auto-Encoding Variational Bayes},
-  author={Diederik P Kingma and Max Welling},
-  year={2014},
-  eprint={1312.6114},
-  archivePrefix={arXiv},
-  primaryClass={stat.ML}
-}
-
-@article{kruschke2013,
-  doi = {10.1037/a0029146},
-  url = {https://doi.org/10.1037/a0029146},
-  year = {2013},
-  publisher = {American Psychological Association ({APA})},
-  volume = {142},
-  number = {2},
-  pages = {573--603},
-  author = {John K. Kruschke},
-  title = {Bayesian estimation supersedes the t test.},
-  journal = {Journal of Experimental Psychology: General}
-}
-
 @misc{kucukelbir2015automatic,
-  title={Automatic Variational Inference in Stan},
-  author={Alp Kucukelbir and Rajesh Ranganath and Andrew Gelman and David M. Blei},
-  year={2015},
-  eprint={1506.03431},
-  archivePrefix={arXiv},
-  primaryClass={stat.ML}
+  title         = {Automatic Variational Inference in Stan},
+  author        = {Alp Kucukelbir and Rajesh Ranganath and Andrew Gelman and David M. Blei},
+  year          = {2015},
+  eprint        = {1506.03431},
+  archiveprefix = {arXiv},
+  primaryclass  = {stat.ML}
 }
-
-@article{lewandowski2009generating,
-  title={Generating random correlation matrices based on vines and extended onion method},
-  author={Lewandowski, Daniel and Kurowicka, Dorota and Joe, Harry},
-  journal={Journal of multivariate analysis},
-  volume={100},
-  number={9},
-  pages={1989--2001},
-  year={2009},
-  publisher={Elsevier}
+@article{ando2007bayesian,
+  title         = {Bayesian predictive information criterion for the evaluation of hierarchical Bayesian and empirical Bayes models},
+  author        = {Ando, Tomohiro},
+  journal       = {Biometrika},
+  volume        = {94},
+  number        = {2},
+  pages         = {443--458},
+  year          = {2007},
+  publisher     = {Oxford University Press},
+  doi           = {10.1093/biomet/asm017}
 }
-
-@book{martin2018bayesian,
-  title={Bayesian analysis with Python: introduction to statistical modeling and probabilistic programming using PyMC3 and ArviZ},
-  author={Martin, Osvaldo},
-  year={2018},
-  publisher={Packt Publishing Ltd}
+@book{breen1996regression,
+  title         = {Regression models: Censored, sample selected, or truncated data},
+  author        = {Breen, Richard and others},
+  volume        = {111},
+  year          = {1996},
+  publisher     = {Sage}
 }
-
-@book{martin2021bayesian,
-  title={Bayesian Modeling and Computation in Python},
-  author={Martin, Osvaldo A and Kumar, Ravin and Lao, Junpeng},
-  year={2021},
-  publisher={Chapman and Hall/CRC},
-  doi={10.1201/9781003019169}
+@misc{carpenter2016hierarchical,
+  title         = {Hierarchical partial pooling for repeated binary trials},
+  author        = {Carpenter, Bob and Gabry, J and Goodrich, B},
+  year          = {2016},
+  publisher     = {Technical report. Retrieved from https://mc-stan. org/users/docum entat ion~\ldots{}}
 }
-
-@book{mcelreath2018statistical,
-  title={Statistical rethinking: A Bayesian course with examples in R and Stan},
-  author={McElreath, Richard},
-  year={2018},
-  publisher={Chapman and Hall/CRC}
-}
-
-@inproceedings{mnih2008advances,
-  title={Probabilistic Matrix Factorization},
-  author={Mnih, Andriy and Salakhutdinov, Russ R},
-  booktitle={Advances in Neural Information Processing Systems},
-  editor={J. Platt and D. Koller and Y. Singer and S. Roweis},
-  publisher={Curran Associates, Inc.},
-  url={https://proceedings.neurips.cc/paper/2007/file/d7322ed717dedf1eb4e6e52a37ea7bcd-Paper.pdf},
-  volume={20},
-  year={2008}
-}
-
-@misc{mnih2013playing,
-  title={Playing Atari with Deep Reinforcement Learning},
-  author={Volodymyr Mnih and Koray Kavukcuoglu and David Silver and Alex Graves and Ioannis Antonoglou and Daan Wierstra and Martin Riedmiller},
-  year={2013},
-  eprint={1312.5602},
-  archivePrefix={arXiv},
-  primaryClass={cs.LG}
-}
-
-@book{molnar2019,
-  title = {Interpretable Machine Learning},
-  author = {Christoph Molnar},
-  year = {2019},
-  subtitle = {A Guide for Making Black Box Models Explainable},
-  url={https://christophm.github.io/interpretable-ml-book/},
-  publisher={Christoph Molnar}
-}
-
-@article{nowlan1992simplifying,
-  title={Simplifying Neural Networks By Soft Weight-Sharing},
-  author={Nowlan, Steven J and Hinton, Geoffrey E},
-  journal={Neural computation},
-  volume={4},
-  number={4},
-  pages={473--493},
-  year={1992},
-  publisher={MIT Press}
-}
-
-
-@inproceedings{salakhutdinov2008bayesian,
-  title={Bayesian Probabilistic Matrix Factorization Using Markov Chain Monte Carlo},
-  author={Salakhutdinov, Ruslan and Mnih, Andriy},
-  booktitle={Proceedings of the 25th international conference on Machine learning},
-  pages={880--887},
-  year={2008},
-  volume={25}
-}
-
-@article{silver2016masteringgo,
-  title={Mastering the game of Go with deep neural networks and tree search},
-  author={D. Silver, A. Huang, C. Maddison et al.},
-  journal={Nature},
-  volume={529},
-  pages={484--489},
-  year={2016},
-  url={https://doi.org/10.1038/nature16961}
-}
-
 @misc{szegedy2014going,
-  title={Going Deeper with Convolutions},
-  author={Christian Szegedy and Wei Liu and Yangqing Jia and Pierre Sermanet and Scott Reed and Dragomir Anguelov and Dumitru Erhan and Vincent Vanhoucke and Andrew Rabinovich},
-  year={2014},
-  eprint={1409.4842},
-  archivePrefix={arXiv},
-  primaryClass={cs.CV}
-  }
-
-
-@INPROCEEDINGS{vanderplas2012astroML,
-  author={{Vanderplas}, J.T. and {Connolly}, A.J.
-          and {Ivezi{\'c}}, {\v Z}. and {Gray}, A.},
-  booktitle={Conference on Intelligent Data Understanding (CIDU)},
-  title={Introduction to astroML: Machine learning for astrophysics},
-  month={oct.},
-  pages={47 -54},
-  doi={10.1109/CIDU.2012.6382200},
-  year={2012}
+  title         = {Going Deeper with Convolutions},
+  author        = {Christian Szegedy and Wei Liu and Yangqing Jia and Pierre Sermanet and Scott Reed and Dragomir Anguelov and Dumitru Erhan and Vincent Vanhoucke and Andrew Rabinovich},
+  year          = {2014},
+  eprint        = {1409.4842},
+  archiveprefix = {arXiv},
+  primaryclass  = {cs.CV}
 }
-
+@book{molnar2019,
+  title         = {Interpretable Machine Learning},
+  author        = {Christoph Molnar},
+  year          = {2019},
+  subtitle      = {A Guide for Making Black Box Models Explainable},
+  url           = {https://christophm.github.io/interpretable-ml-book/},
+  publisher     = {Christoph Molnar}
+}
+@article{silver2016masteringgo,
+  title         = {Mastering the game of Go with deep neural networks and tree search},
+  author        = {D. Silver, A. Huang, C. Maddison et al.},
+  journal       = {Nature},
+  volume        = {529},
+  pages         = {484--489},
+  year          = {2016},
+  url           = {https://doi.org/10.1038/nature16961}
+}
+@misc{hogg2010data,
+  title         = {Data analysis recipes: Fitting a model to data},
+  author        = {David W. Hogg and Jo Bovy and Dustin Lang},
+  year          = {2010},
+  eprint        = {1008.4686},
+  archiveprefix = {arXiv},
+  primaryclass  = {astro-ph.IM}
+}
+@misc{kingma2014autoencoding,
+  title         = {Auto-Encoding Variational Bayes},
+  author        = {Diederik P Kingma and Max Welling},
+  year          = {2014},
+  eprint        = {1312.6114},
+  archiveprefix = {arXiv},
+  primaryclass  = {stat.ML}
+}
+@article{johnson1999,
+  doi           = {10.2307/3802789},
+  url           = {https://doi.org/10.2307/3802789},
+  year          = {1999},
+  month         = jul,
+  publisher     = {{JSTOR}},
+  volume        = {63},
+  number        = {3},
+  pages         = {763},
+  author        = {Douglas H. Johnson},
+  title         = {The Insignificance of Statistical Significance Testing},
+  journal       = {The Journal of Wildlife Management}
+}
+@article{efron1975data,
+  title         = {Data analysis using Stein's estimator and its generalizations},
+  author        = {Efron, Bradley and Morris, Carl},
+  journal       = {Journal of the American Statistical Association},
+  volume        = {70},
+  number        = {350},
+  pages         = {311--319},
+  year          = {1975},
+  publisher     = {Taylor \& Francis}
+}
+@book{gelman2013bayesian,
+  title         = {Bayesian Data Analysis},
+  publisher     = {Chapman and Hall/CRC},
+  author        = {Gelman, Andrew and Carlin, John B. and Stern, Hal S. and Dunson, David B. and Vehtari, Aki and Rubin, Donald B.},
+  year          = {2013}
+}
+@book{gelman2020regression,
+  title         = {Regression and other stories},
+  author        = {Gelman, Andrew and Hill, Jennifer and Vehtari, Aki},
+  year          = {2020},
+  publisher     = {Cambridge University Press}
+}
+@book{gelman2006data,
+  title         = {Data analysis using regression and multilevel/hierarchical models},
+  author        = {Gelman, Andrew and Hill, Jennifer},
+  year          = {2006},
+  publisher     = {Cambridge university press}
+}
+@article{gelman2006multilevel,
+  title         = {Multilevel (hierarchical) modeling: what it can and cannot do},
+  author        = {Gelman, Andrew},
+  journal       = {Technometrics},
+  volume        = {48},
+  number        = {3},
+  pages         = {432--435},
+  year          = {2006},
+  publisher     = {Taylor \& Francis}
+}
+@article{gelman2008scaling,
+  title         = {Scaling regression inputs by dividing by two standard deviations},
+  author        = {Gelman, Andrew},
+  journal       = {Statistics in medicine},
+  volume        = {27},
+  number        = {15},
+  pages         = {2865--2873},
+  year          = {2008},
+  publisher     = {Wiley Online Library},
+  doi           = {10.1002/sim.3107}
+}
+@misc{harper2015movielens,
+  title         = {The MovieLens Datasets: History and Context},
+  author        = {Harper, F. Maxwell and Konstan, Joseph A.},
+  journal       = {ACM Transactions on Interactive Intelligent Systems},
+  volumne       = {5},
+  number        = {4},
+  pages         = {1--19},
+  year          = {2016},
+  month         = {January},
+  url           = {https://doi.org/10.1145/2827872}
+}
+@book{james2021statisticallearning,
+  title         = {An Introduction to Statistical Learning},
+  author        = {James, Gareth ad Witten, Daniela and Hastie, Trevor and Tibshirani, Robert},
+  year          = {2021},
+  publisher     = {Springer},
+  doi           = {https://doi.org/10.1007/978-1-0716-1418-1},
+  issn          = {1431-875X},
+  isbn          = {978-1-0716-1420-4}
+}
+@article{kruschke2013,
+  doi           = {10.1037/a0029146},
+  url           = {https://doi.org/10.1037/a0029146},
+  year          = {2013},
+  publisher     = {American Psychological Association ({APA})},
+  volume        = {142},
+  number        = {2},
+  pages         = {573--603},
+  author        = {John K. Kruschke},
+  title         = {Bayesian estimation supersedes the t test.},
+  journal       = {Journal of Experimental Psychology: General}
+}
+@article{goldberg2001eigentaste,
+  author        = {Ken Goldberg and Theresa Roeder and Chris Perkins},
+  title         = {Eigentaste: A Constant Time Collaborative Filtering Algorithm},
+  journal       = {Information Retrieval},
+  year          = {2001},
+  volume        = {4},
+  pages         = {133--151}
+}
+@article{koren2009matrixfactorization,
+  author        = {Koren, Yehuda and Bell, Robert and Volinsky, Chris},
+  journal       = {Computer},
+  title         = {Matrix Factorization Techniques for Recommender Systems},
+  year          = {2009},
+  volume        = {42},
+  number        = {8},
+  pages         = {30--37},
+  doi           = {10.1109/MC.2009.263}
+}
+@article{lewandowski2009generating,
+  title         = {Generating random correlation matrices based on vines and extended onion method},
+  author        = {Lewandowski, Daniel and Kurowicka, Dorota and Joe, Harry},
+  journal       = {Journal of multivariate analysis},
+  volume        = {100},
+  number        = {9},
+  pages         = {1989--2001},
+  year          = {2009},
+  publisher     = {Elsevier}
+}
+@book{martin2021bayesian,
+  title         = {Bayesian Modeling and Computation in Python},
+  author        = {Martin, Osvaldo A and Kumar, Ravin and Lao, Junpeng},
+  year          = {2021},
+  publisher     = {Chapman and Hall/CRC},
+  doi           = {10.1201/9781003019169}
+}
+@book{martin2018bayesian,
+  title         = {Bayesian analysis with Python: introduction to statistical modeling and probabilistic programming using PyMC3 and ArviZ},
+  author        = {Martin, Osvaldo},
+  year          = {2018},
+  publisher     = {Packt Publishing Ltd}
+}
+@book{mcelreath2018statistical,
+  title         = {Statistical rethinking: A Bayesian course with examples in R and Stan},
+  author        = {McElreath, Richard},
+  year          = {2018},
+  publisher     = {Chapman and Hall/CRC}
+}
+@inproceedings{mnih2008advances,
+  title         = {Probabilistic Matrix Factorization},
+  author        = {Mnih, Andriy and Salakhutdinov, Russ R},
+  booktitle     = {Advances in Neural Information Processing Systems},
+  editor        = {J. Platt and D. Koller and Y. Singer and S. Roweis},
+  publisher     = {Curran Associates, Inc.},
+  url           = {https://proceedings.neurips.cc/paper/2007/file/d7322ed717dedf1eb4e6e52a37ea7bcd-Paper.pdf},
+  volume        = {20},
+  year          = {2008}
+}
+@article{nowlan1992simplifying,
+  title         = {Simplifying Neural Networks By Soft Weight-Sharing},
+  author        = {Nowlan, Steven J and Hinton, Geoffrey E},
+  journal       = {Neural computation},
+  volume        = {4},
+  number        = {4},
+  pages         = {473--493},
+  year          = {1992},
+  publisher     = {MIT Press}
+}
+@inproceedings{salakhutdinov2008bayesian,
+  title         = {Bayesian Probabilistic Matrix Factorization Using Markov Chain Monte Carlo},
+  author        = {Salakhutdinov, Ruslan and Mnih, Andriy},
+  booktitle     = {Proceedings of the 25th international conference on Machine learning},
+  pages         = {880--887},
+  year          = {2008},
+  volume        = {25}
+}
+@article{goodman1999,
+  doi           = {10.7326/0003-4819-130-12-199906150-00008},
+  url           = {https://doi.org/10.7326/0003-4819-130-12-199906150-00008},
+  year          = {1999},
+  month         = jun,
+  publisher     = {American College of Physicians},
+  volume        = {130},
+  number        = {12},
+  pages         = {995},
+  author        = {Steven N. Goodman},
+  title         = {Toward Evidence-Based Medical Statistics. 1: The P Value Fallacy},
+  journal       = {Annals of Internal Medicine}
+}
+@misc{mnih2013playing,
+  title         = {Playing Atari with Deep Reinforcement Learning},
+  author        = {Volodymyr Mnih and Koray Kavukcuoglu and David Silver and Alex Graves and Ioannis Antonoglou and Daan Wierstra and Martin Riedmiller},
+  year          = {2013},
+  eprint        = {1312.5602},
+  archiveprefix = {arXiv},
+  primaryclass  = {cs.LG}
+}
 @book{wilkinson2005grammar,
-  title={The Grammar of Graphics},
-  author={Wilkinson, Leland},
-  year={2005},
-  publisher={Springer},
-  doi={https://doi.org/10.1007/0-387-28695-0},
-  issn={1431-8784},
-  isbn={978-0-387-24544-7}
+  title         = {The Grammar of Graphics},
+  author        = {Wilkinson, Leland},
+  year          = {2005},
+  publisher     = {Springer},
+  doi           = {https://doi.org/10.1007/0-387-28695-0},
+  issn          = {1431-8784},
+  isbn          = {978-0-387-24544-7}
 }
-
-


### PR DESCRIPTION
@MarcoGorelli is there a way to require pre-commit to use a minimum version of node?

This library needs v12 or newer, and while I have been able to update node locally and run the library from the command line, we should not ask contributors to install/update node only to run pre-commit.
