### PR TITLE
add a target to reference the object index page

### DIFF
--- a/examples/object_index/index.rst
+++ b/examples/object_index/index.rst
@@ -1,3 +1,5 @@
+.. _object_index:
+
 ================
 Object use index
 ================


### PR DESCRIPTION
Adds a target to reference the object index page that I will use at least from the PyMC docs.
