### PR TITLE
remove redundant function

### DIFF
--- a/examples/BART/BART_introduction.ipynb
+++ b/examples/BART/BART_introduction.ipynb
@@ -198,7 +198,7 @@
     "with pm.Model() as model_coal:\n",
     "    μ_ = pmx.BART(\"μ_\", X=x_data, Y=y_data, m=20)\n",
     "    μ = pm.Deterministic(\"μ\", np.abs(μ_))\n",
-    "    y_pred = pm.Poisson(\"y_pred\", mu=np.abs(μ), observed=y_data)\n",
+    "    y_pred = pm.Poisson(\"y_pred\", mu=μ, observed=y_data)\n",
     "    idata_coal = pm.sample(random_seed=RANDOM_SEED)"
    ]
   },

--- a/myst_nbs/BART/BART_introduction.myst.md
+++ b/myst_nbs/BART/BART_introduction.myst.md
@@ -88,7 +88,7 @@ In PyMC a BART variable can be defined very similar to other random variables. O
 with pm.Model() as model_coal:
     μ_ = pmx.BART("μ_", X=x_data, Y=y_data, m=20)
     μ = pm.Deterministic("μ", np.abs(μ_))
-    y_pred = pm.Poisson("y_pred", mu=np.abs(μ), observed=y_data)
+    y_pred = pm.Poisson("y_pred", mu=μ, observed=y_data)
     idata_coal = pm.sample(random_seed=RANDOM_SEED)
 ```
 


### PR DESCRIPTION
This is a follow up of #323, this removes the redundant call to `np.abs`