### PR TITLE
Gallery

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,6 @@ repos:
     - id: bibtex-tidy
       files: examples/references.bib
       args: ["--sort=key", --quiet]
-      language_version: 15.14.0
 - repo: local
   hooks:
     - id: watermark

--- a/examples/conf.py
+++ b/examples/conf.py
@@ -1,4 +1,4 @@
-import os, sys
+import os
 from sphinx.application import Sphinx
 
 # -- Project information -----------------------------------------------------
@@ -7,8 +7,6 @@ copyright = "2022, PyMC Community"
 author = "PyMC Community"
 
 # -- General configuration ---------------------------------------------------
-
-sys.path.insert(0, os.path.abspath("../sphinxext"))
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -25,7 +23,6 @@ extensions = [
     "sphinx_codeautolink",
     "notfound.extension",
     "sphinx_gallery.load_style",
-    "gallery_generator",
 ]
 
 # List of patterns, relative to source directory, that match files and

--- a/examples/conf.py
+++ b/examples/conf.py
@@ -1,4 +1,4 @@
-import os
+import os, sys
 from sphinx.application import Sphinx
 
 # -- Project information -----------------------------------------------------
@@ -7,6 +7,8 @@ copyright = "2022, PyMC Community"
 author = "PyMC Community"
 
 # -- General configuration ---------------------------------------------------
+
+sys.path.insert(0, os.path.abspath("../sphinxext"))
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -23,6 +25,7 @@ extensions = [
     "sphinx_codeautolink",
     "notfound.extension",
     "sphinx_gallery.load_style",
+    "gallery_generator",
 ]
 
 # List of patterns, relative to source directory, that match files and
@@ -46,8 +49,22 @@ def hack_nbsphinx(app: Sphinx) -> None:
         GalleryNode,
         NbGallery,
         patched_toctree_resolve,
+        NotebookParser,
+        NbInput,
+        NbOutput,
+        NbInfo,
+        NbWarning,
+        CodeAreaNode,
+        depart_codearea_html,
+        visit_codearea_latex,
+        depart_codearea_latex,
+        GetSizeFromImages,
     )
     from sphinx.environment.adapters import toctree
+
+    nbsphinx_thumbnails = {
+        "case_studies/stochastic_volatility": "_static/stochastic_volatility.png",
+    }
 
     def builder_inited(app: Sphinx):
         if not hasattr(app.env, "nbsphinx_thumbnails"):
@@ -56,7 +73,47 @@ def hack_nbsphinx(app: Sphinx) -> None:
     def do_nothing(*node):
         pass
 
-    app.add_config_value("nbsphinx_thumbnails", {}, rebuild="html")
+    app.add_source_parser(NotebookParser)
+    # app.add_config_value('nbsphinx_execute', 'auto', rebuild='env')
+    app.add_config_value("nbsphinx_kernel_name", "", rebuild="env")
+    app.add_config_value("nbsphinx_execute_arguments", [], rebuild="env")
+    app.add_config_value("nbsphinx_allow_errors", False, rebuild="")
+    app.add_config_value("nbsphinx_timeout", None, rebuild="")
+    app.add_config_value("nbsphinx_codecell_lexer", "none", rebuild="env")
+    app.add_config_value("nbsphinx_prompt_width", "4.5ex", rebuild="html")
+    app.add_config_value("nbsphinx_responsive_width", "540px", rebuild="html")
+    app.add_config_value("nbsphinx_prolog", None, rebuild="env")
+    app.add_config_value("nbsphinx_epilog", None, rebuild="env")
+    app.add_config_value("nbsphinx_input_prompt", "[%s]:", rebuild="env")
+    app.add_config_value("nbsphinx_output_prompt", "[%s]:", rebuild="env")
+    app.add_config_value("nbsphinx_custom_formats", {}, rebuild="env")
+    # Default value is set in config_inited():
+    app.add_config_value("nbsphinx_requirejs_path", None, rebuild="html")
+    # Default value is set in config_inited():
+    app.add_config_value("nbsphinx_requirejs_options", None, rebuild="html")
+    # This will be updated in env_updated():
+    app.add_config_value("nbsphinx_widgets_path", None, rebuild="html")
+    app.add_config_value("nbsphinx_widgets_options", {}, rebuild="html")
+    # app.add_config_value('nbsphinx_thumbnails', {}, rebuild='html')
+    app.add_config_value("nbsphinx_assume_equations", True, rebuild="env")
+
+    app.add_directive("nbinput", NbInput)
+    app.add_directive("nboutput", NbOutput)
+    app.add_directive("nbinfo", NbInfo)
+    app.add_directive("nbwarning", NbWarning)
+    app.add_directive("nbgallery", NbGallery)
+    app.add_node(
+        CodeAreaNode,
+        html=(do_nothing, depart_codearea_html),
+        latex=(visit_codearea_latex, depart_codearea_latex),
+        text=(do_nothing, do_nothing),
+    )
+    app.connect("builder-inited", builder_inited)
+    app.connect("doctree-resolved", doctree_resolved)
+    app.add_post_transform(GetSizeFromImages)
+
+    app.add_config_value("nbsphinx_execute", "auto", rebuild="env")
+    app.add_config_value("nbsphinx_thumbnails", nbsphinx_thumbnails, rebuild="html")
     app.add_directive("nbgallery", NbGallery)
     app.add_node(
         GalleryNode,
@@ -131,7 +188,7 @@ html_logo = "../_static/PyMC.png"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["../_static"]
+html_static_path = ["../_static", "../thumbnails"]
 html_css_files = ["custom.css"]
 templates_path = ["../_templates"]
 html_sidebars = {

--- a/examples/conf.py
+++ b/examples/conf.py
@@ -1,5 +1,6 @@
 import os
 from sphinx.application import Sphinx
+
 # -- Project information -----------------------------------------------------
 project = "PyMC"
 copyright = "2022, PyMC Community"
@@ -21,7 +22,7 @@ extensions = [
     "sphinxcontrib.bibtex",
     "sphinx_codeautolink",
     "notfound.extension",
-    'sphinx_gallery.load_style',
+    "sphinx_gallery.load_style",
 ]
 
 # List of patterns, relative to source directory, that match files and
@@ -36,6 +37,7 @@ exclude_patterns = [
     "extra_installs.md",
     "page_footer.md",
 ]
+
 
 def hack_nbsphinx(app: Sphinx) -> None:
     from nbsphinx import (
@@ -68,8 +70,11 @@ def hack_nbsphinx(app: Sphinx) -> None:
     # Monkey-patch Sphinx TocTree adapter
     toctree.TocTree.resolve = patched_toctree_resolve
 
+
 def setup(app: Sphinx):
     hack_nbsphinx(app)
+
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/examples/gallery.rst
+++ b/examples/gallery.rst
@@ -1,7 +1,20 @@
 Gallery
 =======
 
-Case studies
+
+(Generalized) Linear and Hierarchical Linear Models
+-------------------------
+
+.. nbgallery::
+    :caption: This is a thumbnail gallery:
+    :name: generalized_linear_models
+    :glob:
+    :reversed:
+
+    generalized_linear_models/*
+
+
+Case Studies
 ------------
 
 .. nbgallery::
@@ -12,16 +25,17 @@ Case studies
 
     case_studies/*
 
-Generalized Linear Models
--------------------------
+Diagnostics and Model Criticism
+-------------------------------
 
 .. nbgallery::
     :caption: This is a thumbnail gallery:
-    :name: generalized_linear_models
+    :name: diagnostics_and_criticism
     :glob:
     :reversed:
 
-    generalized_linear_models/*
+    diagnostics_and_criticism/*
+
 
 Gaussian Processes
 ------------------
@@ -33,3 +47,69 @@ Gaussian Processes
     :reversed:
 
     gaussian_processes/*
+
+Inference in ODE models
+-----------------------
+
+.. nbgallery::
+    :caption: This is a thumbnail gallery:
+    :name: ode_models
+    :glob:
+    :reversed:
+
+    ode_models/*
+
+MCMC
+----
+
+.. nbgallery::
+    :caption: This is a thumbnail gallery:
+    :name: samplers
+    :glob:
+    :reversed:
+
+    samplers/*
+
+Mixture Models
+--------------
+
+.. nbgallery::
+    :caption: This is a thumbnail gallery:
+    :name: mixture_models
+    :glob:
+    :reversed:
+
+    mixture_models/*
+
+Survival Analysis
+-----------------
+
+.. nbgallery::
+    :caption: This is a thumbnail gallery:
+    :name: survival_analysis
+    :glob:
+    :reversed:
+
+    survival_analysis/*
+
+Time Series
+-----------
+
+.. nbgallery::
+    :caption: This is a thumbnail gallery:
+    :name: time_series
+    :glob:
+    :reversed:
+
+    time_series/*
+
+Variational Inference
+---------------------
+
+.. nbgallery::
+    :caption: This is a thumbnail gallery:
+    :name: variational_inference
+    :glob:
+    :reversed:
+
+    variational_inference/*

--- a/examples/gallery.rst
+++ b/examples/gallery.rst
@@ -1,0 +1,35 @@
+Gallery
+=======
+
+Case studies
+------------
+
+.. nbgallery::
+    :caption: This is a thumbnail gallery:
+    :name: case_studies
+    :glob:
+    :reversed:
+
+    case_studies/*
+
+Generalized Linear Models
+-------------------------
+
+.. nbgallery::
+    :caption: This is a thumbnail gallery:
+    :name: generalized_linear_models
+    :glob:
+    :reversed:
+
+    generalized_linear_models/*
+
+Gaussian Processes
+------------------
+
+.. nbgallery::
+    :caption: This is a thumbnail gallery:
+    :name: gaussian_processes
+    :glob:
+    :reversed:
+
+    gaussian_processes/*

--- a/examples/index.md
+++ b/examples/index.md
@@ -71,18 +71,6 @@ The left sidebar shows all tags at all times. Like categories, they can be click
 on to reach the page listing all notebooks that contain the tag. If a notebook
 has tags in its metadata they are listed on the right sidebar after the {fas}`tags` icon.
 
-## NB Gallery
-
-```nbgallery
----
-caption: This is a thumbnail gallery:
-name: rst-gallery
-glob:
-reversed:
----
-case_studies/*
-```
-
 :::{toctree}
 :maxdepth: 1
 :hidden:

--- a/examples/index.md
+++ b/examples/index.md
@@ -71,10 +71,22 @@ The left sidebar shows all tags at all times. Like categories, they can be click
 on to reach the page listing all notebooks that contain the tag. If a notebook
 has tags in its metadata they are listed on the right sidebar after the {fas}`tags` icon.
 
+## NB Gallery
+
+```nbgallery
+---
+caption: This is a thumbnail gallery:
+name: rst-gallery
+glob:
+reversed:
+---
+case_studies/*
+```
+
 :::{toctree}
 :maxdepth: 1
 :hidden:
-
+gallery
 blog
 object_index/index
 :::

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -8,3 +8,5 @@ ablog
 sphinxext-opengraph
 sphinx-codeautolink
 sphinx-notfound-page
+nbsphinx
+sphinx-gallery


### PR DESCRIPTION
Using a hack to only use the parts of `nbsphinx` that are required for the gallery but does not clash with `myst_nb`.

Closes #327.

Related: https://github.com/executablebooks/MyST-NB/issues/396
Hack from: https://github.com/PlasmaPy/PlasmaPy/pull/1474#issuecomment-1062476158

I couldn't yet figure out how to get it to work with `md` files rather than `rst`. I also couldn't figure out how to make it look only for `*-ipynb` files, it only worked with `*`.

@OriolAbril do you have an idea?

<img width="646" alt="image" src="https://user-images.githubusercontent.com/674200/170549448-862559fc-b3c4-484e-bc4c-088ec113b474.png">
