### PR TITLE
Refactor fix thumbnails.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 
 _build
 jupyter_execute
+_thumbnails

--- a/_thumbnails/thumbnails/README.txt
+++ b/_thumbnails/thumbnails/README.txt
@@ -1,0 +1,1 @@
+Thumbnails will automatically be generated an placed in this directory by the thumbnail_extractor.py script.

--- a/examples/conf.py
+++ b/examples/conf.py
@@ -25,7 +25,7 @@ extensions = [
     "sphinx_codeautolink",
     "notfound.extension",
     "sphinx_gallery.load_style",
-    "gallery_generator",
+    "thumbnail_extractor",
 ]
 
 # List of patterns, relative to source directory, that match files and
@@ -57,7 +57,9 @@ def hack_nbsphinx(app: Sphinx) -> None:
     nb_paths = glob("examples/*/*.ipynb")
     nbsphinx_thumbnails = {}
     for nb_path in nb_paths:
-        png_file = os.path.join("_static", os.path.splitext(os.path.split(nb_path)[-1])[0] + ".png")
+        png_file = os.path.join(
+            "thumbnails", os.path.splitext(os.path.split(nb_path)[-1])[0] + ".png"
+        )
         nb_path_rel = os.path.splitext(
             os.path.join(*os.path.normpath(nb_path).split(os.path.sep)[1:])
         )[0]
@@ -145,7 +147,8 @@ html_logo = "../_static/PyMC.png"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["../_static", "../_images", "../_templates"]
+html_static_path = ["../_static"]
+html_extra_path = ["../_thumbnails"]
 html_css_files = ["custom.css"]
 templates_path = ["../_templates"]
 html_sidebars = {

--- a/examples/conf.py
+++ b/examples/conf.py
@@ -62,10 +62,6 @@ def hack_nbsphinx(app: Sphinx) -> None:
         )
         nb_path_rel = os.path.splitext(nb_path)[0]
         nbsphinx_thumbnails[nb_path_rel] = png_file
-    print(nbsphinx_thumbnails)
-    import pdb
-
-    pdb.set_trace
 
     def builder_inited(app: Sphinx):
         if not hasattr(app.env, "nbsphinx_thumbnails"):

--- a/examples/conf.py
+++ b/examples/conf.py
@@ -54,16 +54,18 @@ def hack_nbsphinx(app: Sphinx) -> None:
 
     from glob import glob
 
-    nb_paths = glob("examples/*/*.ipynb")
+    nb_paths = glob("*/*.ipynb")
     nbsphinx_thumbnails = {}
     for nb_path in nb_paths:
         png_file = os.path.join(
             "thumbnails", os.path.splitext(os.path.split(nb_path)[-1])[0] + ".png"
         )
-        nb_path_rel = os.path.splitext(
-            os.path.join(*os.path.normpath(nb_path).split(os.path.sep)[1:])
-        )[0]
+        nb_path_rel = os.path.splitext(nb_path)[0]
         nbsphinx_thumbnails[nb_path_rel] = png_file
+    print(nbsphinx_thumbnails)
+    import pdb
+
+    pdb.set_trace
 
     def builder_inited(app: Sphinx):
         if not hasattr(app.env, "nbsphinx_thumbnails"):

--- a/sphinxext/thumbnail_extractor.py
+++ b/sphinxext/thumbnail_extractor.py
@@ -90,10 +90,10 @@ def main(app):
     logger.info("Starting thumbnail extractor.")
     from glob import glob
 
-    nb_paths = glob("examples/*/*.ipynb")
+    nb_paths = glob("*/*.ipynb")
 
     for nb_path in nb_paths:
-        nbg = NotebookGenerator(nb_path, "")
+        nbg = NotebookGenerator(nb_path, "..")
         nbg.gen_previews()
 
 

--- a/sphinxext/thumbnail_extractor.py
+++ b/sphinxext/thumbnail_extractor.py
@@ -19,8 +19,8 @@ import sphinx
 
 logger = sphinx.util.logging.getLogger(__name__)
 
-DOC_SRC = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-DEFAULT_IMG_LOC = os.path.join(os.path.dirname(DOC_SRC), "pymc-examples/_static", "PyMC.png")
+DOC_SRC = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_IMG_LOC = os.path.join(os.path.dirname(DOC_SRC), "_static", "PyMC.png")
 
 
 def create_thumbnail(infile, width=275, height=275, cx=0.5, cy=0.5, border=4):

--- a/sphinxext/thumbnail_extractor.py
+++ b/sphinxext/thumbnail_extractor.py
@@ -15,6 +15,10 @@ import matplotlib.pyplot as plt
 
 from matplotlib import image
 
+import sphinx
+
+logger = sphinx.util.logging.getLogger(__name__)
+
 DOC_SRC = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DEFAULT_IMG_LOC = os.path.join(os.path.dirname(DOC_SRC), "pymc-examples/_static", "PyMC.png")
 
@@ -52,7 +56,7 @@ class NotebookGenerator:
     def __init__(self, filename, target_dir):
         self.basename = os.path.basename(filename)
         stripped_name = os.path.splitext(self.basename)[0]
-        self.image_dir = os.path.join(target_dir, "_static")
+        self.image_dir = os.path.join(target_dir, "_thumbnails", "thumbnails")
         self.png_path = os.path.join(self.image_dir, f"{stripped_name}.png")
         with open(filename) as fid:
             self.json_source = json.load(fid)
@@ -75,12 +79,15 @@ class NotebookGenerator:
             with open(self.png_path, "wb") as buff:
                 buff.write(preview)
         else:
-            print(f"didn't find for {self.png_path}")
+            logger.warning(
+                f"Didn't find any pictures in {self.basename}", type="thumbnail_extractor"
+            )
             shutil.copy(self.default_image_loc, self.png_path)
         create_thumbnail(self.png_path)
 
 
 def main(app):
+    logger.info("Starting thumbnail extractor.")
     from glob import glob
 
     nb_paths = glob("examples/*/*.ipynb")


### PR DESCRIPTION
Rename gallery_generator to thumbnail_extractor. Add debug output. Write thumbnails to separate directory.

Fixes https://github.com/pymc-devs/pymc-examples/issues/346.