### PR TITLE
add args to codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,4 +108,4 @@ repos:
   hooks:
   - id: codespell
     files: myst_nbs/
-    args: ["--write-changes", "--ignore-words-list", "hist,fpr,fro,lik"]
+    args: ["--write-changes", "--ignore-words-list", "hist,fpr,fro,lik", "--uri-ignore-words-list", "*"]


### PR DESCRIPTION
Another attempt at getting this PR right. I messed up my main branch - hopefully it is fixed. If so, this PR should just consist of one change which adds some args to `codespell` to make it ignore URI's.

- This PR is a blocker for a new notebook: #391 
- It should also resolve #385