### PR TITLE
Notebook: sampler_stats; update links, clean up sections

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,7 +68,6 @@ repos:
                examples/case_studies/blackbox_external_likelihood.ipynb|
                examples/case_studies/blackbox_external_likelihood_numpy.ipynb|
                examples/case_studies/item_response_nba.ipynb|
-               examples/diagnostics_and_criticism/sampler-stats.ipynb|
                examples/gaussian_processes/GP-MaunaLoa2.ipynb|
                examples/generalized_linear_models/GLM-logistic.ipynb|
                examples/generalized_linear_models/GLM-out-of-sample-predictions.ipynb|

--- a/examples/diagnostics_and_criticism/sampler-stats.ipynb
+++ b/examples/diagnostics_and_criticism/sampler-stats.ipynb
@@ -7,11 +7,6 @@
     "(sampler_stats)=\n",
     "# Sampler Statistics\n",
     "\n",
-    "When checking for convergence or when debugging a badly behaving\n",
-    "sampler, it is often helpful to take a closer look at what the\n",
-    "sampler is doing. For this purpose some samplers export\n",
-    "statistics for each generated sample.\n",
-    "\n",
     ":::{post} May 31, 2022\n",
     ":tags: diagnostics \n",
     ":category: beginner\n",
@@ -65,6 +60,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "When checking for convergence or when debugging a badly behaving sampler, it is often helpful to take a closer look at what the sampler is doing. For this purpose some samplers export statistics for each generated sample. \n",
+    "\n",
     "As a minimal example we sample from a standard normal distribution:"
    ]
   },
@@ -151,7 +148,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- `Note`: NUTS provides the following statistics( these are internal statistics that the sampler uses, you don't need to do anything with them when using PyMC3, to learn more about them, [check this page](https://docs.pymc.io/api/inference.html#module-pymc3.step_methods.hmc.nuts)."
+    "- `Note`: NUTS provides the following statistics (these are internal statistics that the sampler uses, you don't need to do anything with them when using PyMC, to learn more about them, [`pymc.NUTS`](https://www.pymc.io/projects/docs/en/latest/api/generated/pymc.NUTS.html#pymc.NUTS)."
    ]
   },
   {
@@ -1747,6 +1744,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Authors\n",
+    "* Moved from pymc to pymc-examples repo in December 2020 ([pymc-examples#8](https://github.com/pymc-devs/pymc-examples/pull/8))\n",
+    "* Updated by Meenal Jhajharia in April 2021 ([pymc-examples#95](https://github.com/pymc-devs/pymc-examples/pull/95))\n",
+    "* Updated to v4 by Christian Luhmann in May 2022 ([pymc-examples#338](https://github.com/pymc-devs/pymc-examples/pull/338))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Watermark"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 16,
    "metadata": {},
@@ -1781,14 +1795,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* Updated by Meenal Jhajharia\n",
-    "* Updated by Christian Luhmann"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     ":::{include} ../page_footer.md\n",
     ":::"
    ]
@@ -1799,7 +1805,7 @@
    "notebook_metadata_filter": "substitutions"
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/diagnostics_and_criticism/sampler-stats.ipynb
+++ b/examples/diagnostics_and_criticism/sampler-stats.ipynb
@@ -8,7 +8,7 @@
     "# Sampler Statistics\n",
     "\n",
     ":::{post} May 31, 2022\n",
-    ":tags: diagnostics \n",
+    ":tags: diagnostics\n",
     ":category: beginner\n",
     ":author: Meenal Jhajharia, Christian Luhmann\n",
     ":::"
@@ -60,7 +60,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When checking for convergence or when debugging a badly behaving sampler, it is often helpful to take a closer look at what the sampler is doing. For this purpose some samplers export statistics for each generated sample. \n",
+    "When checking for convergence or when debugging a badly behaving sampler, it is often helpful to take a closer look at what the sampler is doing. For this purpose some samplers export statistics for each generated sample.\n",
     "\n",
     "As a minimal example we sample from a standard normal distribution:"
    ]
@@ -692,7 +692,7 @@
    "metadata": {},
    "source": [
     "Some points to `Note`:\n",
-    "- Some of the sample statistics used by NUTS are renamed when converting to `InferenceData` to follow [ArviZ's naming convention](https://arviz-devs.github.io/arviz/schema/schema.html#sample-stats), while some are specific to PyMC3 and keep their internal PyMC3 name in the resulting InferenceData object.\n",
+    "- Some of the sample statistics used by NUTS are renamed when converting to `InferenceData` to follow {ref}`ArviZ's naming convention <arviz:schema>`, while some are specific to PyMC3 and keep their internal PyMC3 name in the resulting InferenceData object.\n",
     "- `InferenceData` also stores additional info like the date, versions used, sampling time and tuning steps as attributes."
    ]
   },

--- a/examples/diagnostics_and_criticism/sampler-stats.ipynb
+++ b/examples/diagnostics_and_criticism/sampler-stats.ipynb
@@ -148,7 +148,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- `Note`: NUTS provides the following statistics (these are internal statistics that the sampler uses, you don't need to do anything with them when using PyMC, to learn more about them, [`pymc.NUTS`](https://www.pymc.io/projects/docs/en/latest/api/generated/pymc.NUTS.html#pymc.NUTS)."
+    "- `Note`: NUTS provides the following statistics (these are internal statistics that the sampler uses, you don't need to do anything with them when using PyMC, to learn more about them, {class}`pymc.NUTS`."
    ]
   },
   {
@@ -1748,7 +1748,6 @@
    "metadata": {},
    "source": [
     "## Authors\n",
-    "* Moved from pymc to pymc-examples repo in December 2020 ([pymc-examples#8](https://github.com/pymc-devs/pymc-examples/pull/8))\n",
     "* Updated by Meenal Jhajharia in April 2021 ([pymc-examples#95](https://github.com/pymc-devs/pymc-examples/pull/95))\n",
     "* Updated to v4 by Christian Luhmann in May 2022 ([pymc-examples#338](https://github.com/pymc-devs/pymc-examples/pull/338))"
    ]
@@ -1805,7 +1804,7 @@
    "notebook_metadata_filter": "substitutions"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1819,7 +1818,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.9.10"
   }
  },
  "nbformat": 4,

--- a/myst_nbs/diagnostics_and_criticism/sampler-stats.myst.md
+++ b/myst_nbs/diagnostics_and_criticism/sampler-stats.myst.md
@@ -7,7 +7,7 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.13.7
 kernelspec:
-  display_name: Python 3
+  display_name: Python 3 (ipykernel)
   language: python
   name: python3
 ---
@@ -54,7 +54,7 @@ with model:
     idata = pm.sample(2000, tune=1000, init=None, step=step, chains=4)
 ```
 
-- `Note`: NUTS provides the following statistics (these are internal statistics that the sampler uses, you don't need to do anything with them when using PyMC, to learn more about them, [`pymc.NUTS`](https://www.pymc.io/projects/docs/en/latest/api/generated/pymc.NUTS.html#pymc.NUTS).
+- `Note`: NUTS provides the following statistics (these are internal statistics that the sampler uses, you don't need to do anything with them when using PyMC, to learn more about them, {class}`pymc.NUTS`.
 
 ```{code-cell} ipython3
 idata.sample_stats
@@ -187,7 +187,6 @@ az.plot_density(
 ```
 
 ## Authors
-* Moved from pymc to pymc-examples repo in December 2020 ([pymc-examples#8](https://github.com/pymc-devs/pymc-examples/pull/8))
 * Updated by Meenal Jhajharia in April 2021 ([pymc-examples#95](https://github.com/pymc-devs/pymc-examples/pull/95))
 * Updated to v4 by Christian Luhmann in May 2022 ([pymc-examples#338](https://github.com/pymc-devs/pymc-examples/pull/338))
 

--- a/myst_nbs/diagnostics_and_criticism/sampler-stats.myst.md
+++ b/myst_nbs/diagnostics_and_criticism/sampler-stats.myst.md
@@ -7,18 +7,13 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.13.7
 kernelspec:
-  display_name: Python 3 (ipykernel)
+  display_name: Python 3
   language: python
   name: python3
 ---
 
 (sampler_stats)=
 # Sampler Statistics
-
-When checking for convergence or when debugging a badly behaving
-sampler, it is often helpful to take a closer look at what the
-sampler is doing. For this purpose some samplers export
-statistics for each generated sample.
 
 :::{post} May 31, 2022
 :tags: diagnostics 
@@ -43,6 +38,8 @@ az.style.use("arviz-darkgrid")
 plt.rcParams["figure.constrained_layout.use"] = False
 ```
 
+When checking for convergence or when debugging a badly behaving sampler, it is often helpful to take a closer look at what the sampler is doing. For this purpose some samplers export statistics for each generated sample. 
+
 As a minimal example we sample from a standard normal distribution:
 
 ```{code-cell} ipython3
@@ -57,7 +54,7 @@ with model:
     idata = pm.sample(2000, tune=1000, init=None, step=step, chains=4)
 ```
 
-- `Note`: NUTS provides the following statistics( these are internal statistics that the sampler uses, you don't need to do anything with them when using PyMC3, to learn more about them, [check this page](https://docs.pymc.io/api/inference.html#module-pymc3.step_methods.hmc.nuts).
+- `Note`: NUTS provides the following statistics (these are internal statistics that the sampler uses, you don't need to do anything with them when using PyMC, to learn more about them, [`pymc.NUTS`](https://www.pymc.io/projects/docs/en/latest/api/generated/pymc.NUTS.html#pymc.NUTS).
 
 ```{code-cell} ipython3
 idata.sample_stats
@@ -189,15 +186,19 @@ az.plot_density(
 );
 ```
 
+## Authors
+* Moved from pymc to pymc-examples repo in December 2020 ([pymc-examples#8](https://github.com/pymc-devs/pymc-examples/pull/8))
+* Updated by Meenal Jhajharia in April 2021 ([pymc-examples#95](https://github.com/pymc-devs/pymc-examples/pull/95))
+* Updated to v4 by Christian Luhmann in May 2022 ([pymc-examples#338](https://github.com/pymc-devs/pymc-examples/pull/338))
+
++++
+
+## Watermark
+
 ```{code-cell} ipython3
 %load_ext watermark
 %watermark -n -u -v -iv -w
 ```
-
-* Updated by Meenal Jhajharia
-* Updated by Christian Luhmann
-
-+++
 
 :::{include} ../page_footer.md
 :::

--- a/myst_nbs/diagnostics_and_criticism/sampler-stats.myst.md
+++ b/myst_nbs/diagnostics_and_criticism/sampler-stats.myst.md
@@ -16,7 +16,7 @@ kernelspec:
 # Sampler Statistics
 
 :::{post} May 31, 2022
-:tags: diagnostics 
+:tags: diagnostics
 :category: beginner
 :author: Meenal Jhajharia, Christian Luhmann
 :::
@@ -38,7 +38,7 @@ az.style.use("arviz-darkgrid")
 plt.rcParams["figure.constrained_layout.use"] = False
 ```
 
-When checking for convergence or when debugging a badly behaving sampler, it is often helpful to take a closer look at what the sampler is doing. For this purpose some samplers export statistics for each generated sample. 
+When checking for convergence or when debugging a badly behaving sampler, it is often helpful to take a closer look at what the sampler is doing. For this purpose some samplers export statistics for each generated sample.
 
 As a minimal example we sample from a standard normal distribution:
 
@@ -91,7 +91,7 @@ The sample statistics variables are defined as follows:
 +++
 
 Some points to `Note`:
-- Some of the sample statistics used by NUTS are renamed when converting to `InferenceData` to follow [ArviZ's naming convention](https://arviz-devs.github.io/arviz/schema/schema.html#sample-stats), while some are specific to PyMC3 and keep their internal PyMC3 name in the resulting InferenceData object.
+- Some of the sample statistics used by NUTS are renamed when converting to `InferenceData` to follow {ref}`ArviZ's naming convention <arviz:schema>`, while some are specific to PyMC3 and keep their internal PyMC3 name in the resulting InferenceData object.
 - `InferenceData` also stores additional info like the date, versions used, sampling time and tuning steps as attributes.
 
 ```{code-cell} ipython3


### PR DESCRIPTION
# References
- Towards #394
- References [pymc-devs/pymc #5460](https://github.com/pymc-devs/pymc/issues/5460) (Update example gallery style and formatting)
- References Project Board: https://github.com/pymc-devs/pymc-examples/projects/1

+ [x] Notebook follows style guide https://docs.pymc.io/en/latest/contributing/jupyter_style.html
+ [x] PR description contains a link to the relevant issue: a tracker one for existing notebooks or a proposal one for new notebooks
+ [x] Check the notebook is not excluded from any pre-commit check: https://github.com/pymc-devs/pymc-examples/blob/main/.pre-commit-config.yaml

### Helpful links
* https://github.com/pymc-devs/pymc-examples/blob/main/CONTRIBUTING.md

### Notes for the Reviewer
- made some minor updates to the notebook, to be consistent with other notebooks and the style guide.

#DataUmbrellaPyMCSprint
