### PR TITLE
some general website and infrastructure fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,10 +54,16 @@ repos:
       minimum_pre_commit_version: 2.8.0
       name: Check notebooks have watermark (see Jupyter style guide from PyMC docs)
       types: [jupyter]
-    - id: no-internal-links
-      name: Check no internal links are in the docs
+    - id: notebook_name
+      entry: '\(notebook_name\)='
+      language: pygrep
+      minimum_pre_commit_version: 2.8.0
+      name: Check notebooks do not use literally notebook_name as target
+      types: [jupyter]
+    - id: no-references-as-links
+      name: Check no references that should be sphinx cross-references are urls
       description: >-
-        'A quick check to prevent urls pointing to pymc docs'
+        'A quick check to prevent urls pointing to pymc docs or other sphinx built docs like arviz, numpy, scipy...'
       files: ^examples/
       exclude: >
           (?x)(index.md|

--- a/examples/conf.py
+++ b/examples/conf.py
@@ -222,6 +222,7 @@ rediraffe_redirects = {
 remove_from_toctrees = [
     "BART/*",
     "case_studies/*",
+    "causal_inference/*",
     "diagnostics_and_criticism/*",
     "gaussian_processes/*",
     "generalized_linear_models/*",

--- a/examples/conf.py
+++ b/examples/conf.py
@@ -138,10 +138,12 @@ html_theme_options = {
     ],
     "logo_link": "https://www.pymc.io",
     "search_bar_text": "Search...",
-    "navbar_end": ["search-field.html", "navbar-icon-links.html"],
+    "navbar_end": ["navbar-icon-links.html"],
     "page_sidebar_items": ["postcard", "page-toc", "edit-this-page", "donate"],
     "google_analytics_id": "G-6KPRBTE6WV",
-    "logo_link": "https://www.pymc.io",
+    "logo": {
+        "link": "https://www.pymc.io",
+    },
 }
 version = os.environ.get("READTHEDOCS_VERSION", "")
 version = version if "." in version else "main"

--- a/examples/conf.py
+++ b/examples/conf.py
@@ -136,11 +136,11 @@ html_theme_options = {
             "icon": "fab fa-discourse",
         },
     ],
-    "logo_link": "https://www.pymc.io",
     "search_bar_text": "Search...",
     "navbar_end": ["navbar-icon-links.html"],
     "page_sidebar_items": ["postcard", "page-toc", "edit-this-page", "donate"],
     "google_analytics_id": "G-6KPRBTE6WV",
+    "header_links_before_dropdown": 6,
     "logo": {
         "link": "https://www.pymc.io",
     },

--- a/examples/generalized_linear_models/GLM-hierarchical.ipynb
+++ b/examples/generalized_linear_models/GLM-hierarchical.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(notebook_name)=\n",
+    "(GLM-hierarchical)=\n",
     "# GLM: Hierarchical Linear Regression\n",
     "\n",
     ":::{post} May 20, 2022\n",

--- a/myst_nbs/generalized_linear_models/GLM-hierarchical.myst.md
+++ b/myst_nbs/generalized_linear_models/GLM-hierarchical.myst.md
@@ -11,7 +11,7 @@ kernelspec:
   name: python3
 ---
 
-(notebook_name)=
+(GLM-hierarchical)=
 # GLM: Hierarchical Linear Regression
 
 :::{post} May 20, 2022

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,6 +1,6 @@
 myst-nb
 sphinx==5.0.2 # see https://github.com/pymc-devs/pymc-examples/issues/409
-pydata_sphinx_theme<0.10.1
+pydata_sphinx_theme>=0.11.0
 sphinx-design
 sphinx-copybutton
 sphinxcontrib-bibtex


### PR DESCRIPTION
closes #437, related to https://github.com/pymc-devs/pymc/issues/6115. Also adds a pre-commit check to make sure nobody copies `(notebook_name)=` literally as the target at the top of the bottom. The [box labeled important](https://www.pymc.io/projects/docs/en/latest/contributing/jupyter_style.html#first-cell) has proved time and time again to not be enough. I might even remove the box and leave the actual text description and pre-commit check.
