### PR TITLE
[fix BVAR #523] fix indentation in bvar calc_ar

### DIFF
--- a/examples/time_series/bayesian_var_model.myst.md
+++ b/examples/time_series/bayesian_var_model.myst.md
@@ -5,9 +5,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: Python 3.9.0 ('pymc_ar_ex')
+  display_name: myjlabenv
   language: python
-  name: python3
+  name: myjlabenv
 ---
 
 (Bayesian Vector Autoregressive Models)=
@@ -145,7 +145,7 @@ def calc_ar_step(lag_coefs, n_eqs, n_lags, df):
             ],
             axis=0,
         )
-    ars.append(ar)
+        ars.append(ar)
     beta = pm.math.stack(ars, axis=-1)
 
     return beta
@@ -275,7 +275,7 @@ az.summary(idata_fake_data, var_names=["alpha", "lag_coefs", "noise_chol_corr"])
 ```
 
 ```{code-cell} ipython3
-az.plot_posterior(idata_fake_data, var_names=["alpha"], ref_val=[18, 8]);
+az.plot_posterior(idata_fake_data, var_names=["alpha"], ref_val=[8, 18]);
 ```
 
 Next we'll plot the posterior predictive distribution to check that the fitted model can capture the patterns in the observed data. This is the primary test of goodness of fit.
@@ -754,6 +754,7 @@ In the next post in this series we will spend some time digging into the implied
 
 ## Authors
 * Adapted from the PYMC labs [Blog post](https://www.pymc-labs.io/blog-posts/bayesian-vector-autoregression/) and Jim Savage's discussion [here](https://rpubs.com/jimsavage/hierarchical_var) by [Nathaniel Forde](https://nathanielf.github.io/) in November 2022 ([pymc-examples#456](https://github.com/pymc-devs/pymc-examples/pull/456))
+* Reexecuted by Nathaniel Forde on Feb, 2023 ([pymc_examples#523](https://github.com/pymc-devs/pymc-examples/issues/523))
 
 +++
 

--- a/examples/time_series/bayesian_var_model.myst.md
+++ b/examples/time_series/bayesian_var_model.myst.md
@@ -311,7 +311,7 @@ def plot_ppc(idata, df, group="posterior_predictive"):
     fig, axs = plt.subplots(2, 1, figsize=(25, 15))
     df = pd.DataFrame(idata_fake_data["observed_data"]["obs"].data, columns=["x", "y"])
     axs = axs.flatten()
-    ppc = az.extract_dataset(idata, group=group, num_samples=100)["obs"]
+    ppc = az.extract(idata, group=group, num_samples=100)["obs"]
     # Minus the lagged terms and the constant
     shade_background(ppc, axs, 0, "inferno")
     axs[0].plot(np.arange(ppc.shape[0]), ppc[:, 0, :].mean(axis=1), color="cyan", label="Mean")
@@ -409,7 +409,7 @@ def plot_ppc_macro(idata, df, group="posterior_predictive"):
     df = pd.DataFrame(idata["observed_data"]["obs"].data, columns=["dl_gdp", "dl_cons"])
     fig, axs = plt.subplots(2, 1, figsize=(20, 10))
     axs = axs.flatten()
-    ppc = az.extract_dataset(idata, group=group, num_samples=100)["obs"]
+    ppc = az.extract(idata, group=group, num_samples=100)["obs"]
 
     shade_background(ppc, axs, 0, "inferno")
     axs[0].plot(np.arange(ppc.shape[0]), ppc[:, 0, :].mean(axis=1), color="cyan", label="Mean")
@@ -704,7 +704,7 @@ for ax, country in zip(axs, countries):
         idata_full_test["observed_data"][f"obs_{country}"].data,
         columns=["dl_gdp", "dl_cons", "dl_gfcf"],
     )
-    ppc = az.extract_dataset(idata_full_test, group="posterior_predictive", num_samples=100)[
+    ppc = az.extract(idata_full_test, group="posterior_predictive", num_samples=100)[
         f"obs_{country}"
     ]
     if country == "Ireland":


### PR DESCRIPTION
# Fixing indentation error on calc_ar_step function. Re-executing the notebook. Nothing substantial changes. 

Addressing this issue: 
https://github.com/pymc-devs/pymc-examples/issues/523

+ [X] Notebook follows style guide https://docs.pymc.io/en/latest/contributing/jupyter_style.html
+ [X] PR description contains a link to the relevant issue:
  * a tracker one for existing notebooks (tracker issues have the "tracker id" label)
  * or a proposal one for new notebooks
+ [X] Check the notebook is not excluded from any pre-commit check: https://github.com/pymc-devs/pymc-examples/blob/main/.pre-commit-config.yaml

