### PR TITLE
Fix a small typo in the survival analysis notebook

### DIFF
--- a/examples/survival_analysis/survival_analysis.ipynb
+++ b/examples/survival_analysis/survival_analysis.ipynb
@@ -209,7 +209,7 @@
     "\n",
     "Solving this differential equation for the survival function shows that\n",
     "\n",
-    "$$S(t) = \\exp\\left(-\\int_0^s \\lambda(s)\\ ds\\right).$$\n",
+    "$$S(t) = \\exp\\left(-\\int_0^t \\lambda(s)\\ ds\\right).$$\n",
     "\n",
     "This representation of the survival function shows that the cumulative hazard function\n",
     "\n",

--- a/examples/survival_analysis/survival_analysis.myst.md
+++ b/examples/survival_analysis/survival_analysis.myst.md
@@ -87,7 +87,7 @@ $$\begin{align*}
 
 Solving this differential equation for the survival function shows that
 
-$$S(t) = \exp\left(-\int_0^s \lambda(s)\ ds\right).$$
+$$S(t) = \exp\left(-\int_0^t \lambda(s)\ ds\right).$$
 
 This representation of the survival function shows that the cumulative hazard function
 


### PR DESCRIPTION
# {Insert Description}
<!-- Thank you so much for your PR to pymc-examples!

To make the merge process smoother we've provided some links and a checklist below.

We understand that PRs can sometimes be overwhelming, especially as the reviews start coming in.
Please let us know if the reviews are unclear or the recommended next step seems overly demanding,
if you would like help in addressing a reviewer's comments,
or if you have been waiting too long to hear back on your PR. -->

+ [X] Notebook follows style guide https://docs.pymc.io/en/latest/contributing/jupyter_style.html
+ [X] PR description contains a link to the relevant issue:
  * a tracker one for existing notebooks (tracker issues have the "tracker id" label)
  * or a proposal one for new notebooks
+ [X] Check the notebook is not excluded from any pre-commit check: https://github.com/pymc-devs/pymc-examples/blob/main/.pre-commit-config.yaml


Fixes a typo in an integral boundary related to the survival function.