### PR TITLE
Fix Stucchio URL

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,5 +15,5 @@ jobs:
     - uses: actions/setup-python@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: '15'
+        node-version: '18'
     - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
             |examples/samplers/MLDA_variance_reduction_linear_regression\.ipynb$
 
 - repo: https://github.com/FlamingTempura/bibtex-tidy
-  rev: v1.8.5
+  rev: v1.11.0
   hooks:
     - id: bibtex-tidy
       files: examples/references.bib

--- a/examples/references.bib
+++ b/examples/references.bib
@@ -555,7 +555,7 @@
   note          = {working paper or preprint},
   year          = {2015},
   month         = Feb,
-  pdf           = {https://hal.archives-ouvertes.fr/hal-01119942v1/file/PolarGP\_CircularDomains.pdf}
+  pdf           = {https://hal.archives-ouvertes.fr/hal-01119942v1/file/PolarGP_CircularDomains.pdf}
 }
 @book{pearl2000causality,
   title         = {Causality: Models, reasoning and inference},

--- a/examples/references.bib
+++ b/examples/references.bib
@@ -648,7 +648,7 @@
   title         = {Bayesian A/B Testing at VWO},
   author        = {Stucchio, Chris},
   year          = {2015},
-  url           = {https://vwo.com/downloads/VWO\_SmartStats\_technical\_whitepaper.pdf}
+  url           = {https://vwo.com/downloads/VWO_SmartStats_technical_whitepaper.pdf}
 }
 @misc{szegedy2014going,
   title         = {Going Deeper with Convolutions},


### PR DESCRIPTION
The backslashes are appearing in the actual URL

Here's the actual page:

https://www.pymc.io/projects/examples/en/latest/case_studies/bayesian_ab_testing_introduction.html#id79 

Note that this old PyMC3 page is much higher on Google:
https://www.pymc.io/projects/docs/en/v3/pymc-examples/examples/case_studies/bayesian_ab_testing.html

Presumably the backslashes were put there for a reason. Maybe something changed with respect to the parsing though? (I'm just saying that I hope fixing this doesn't break something else.)

I'm ignoring the template since I'm modifying the `.bib` file and not the notebook file.

# {Insert Description}
<!-- Thank you so much for your PR to pymc-examples!

To make the merge process smoother we've provided some links and a checklist below.

We understand that PRs can sometimes be overwhelming, especially as the reviews start coming in.
Please let us know if the reviews are unclear or the recommended next step seems overly demanding,
if you would like help in addressing a reviewer's comments,
or if you have been waiting too long to hear back on your PR. -->

+ [ ] Notebook follows style guide https://docs.pymc.io/en/latest/contributing/jupyter_style.html
+ [ ] PR description contains a link to the relevant issue:
  * a tracker one for existing notebooks (tracker issues have the "tracker id" label)
  * or a proposal one for new notebooks
+ [ ] Check the notebook is not excluded from any pre-commit check: https://github.com/pymc-devs/pymc-examples/blob/main/.pre-commit-config.yaml


### Helpful links
* https://github.com/pymc-devs/pymc-examples/blob/main/CONTRIBUTING.md


<!-- readthedocs-preview pymc-examples start -->
----
:books: Documentation preview :books:: https://pymc-examples--567.org.readthedocs.build/en/567/

<!-- readthedocs-preview pymc-examples end -->