### PR TITLE
Update requirements-docs.txt to sphinx-theme=0.14

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,6 +1,6 @@
 myst-nb
 sphinx>=5
-pymc-sphinx-theme==0.1
+pymc-sphinx-theme==0.14
 sphinx-design
 sphinx-copybutton
 sphinxcontrib-bibtex


### PR DESCRIPTION
Updated sphinx-theme to 0.14 which fixed the citations (#591) and badges at the top of the page

<!-- readthedocs-preview pymc-examples start -->
----
:books: Documentation preview :books:: https://pymc-examples--596.org.readthedocs.build/en/596/

<!-- readthedocs-preview pymc-examples end -->