### PR TITLE
Add website metadata

### DIFF
--- a/examples/conf.py
+++ b/examples/conf.py
@@ -28,6 +28,7 @@ extensions = [
     "notfound.extension",
     "thumbnail_extractor",
     "sphinxext.rediraffe",
+    "sphinx_sitemap",
 ]
 
 # List of patterns, relative to source directory, that match files and
@@ -69,6 +70,7 @@ def setup(app: Sphinx):
 
 # theme options
 html_theme = "pymc_sphinx_theme"
+html_baseurl = "https://www.pymc.io/projects/examples/"
 html_theme_options = {
     "secondary_sidebar_items": ["postcard", "page-toc", "edit-this-page", "sourcelink", "donate"],
     "navbar_start": ["navbar-logo"],
@@ -103,13 +105,13 @@ html_title = "PyMC example gallery"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["../_static"]
-html_extra_path = ["../_thumbnails"]
+html_extra_path = ["../_thumbnails", "robots.txt"]
 templates_path = ["../_templates"]
 html_sidebars = {
     "**": [
         "sidebar-nav-bs.html",
         "postcard_categories.html",
-        "tagcloud.html",
+        "ablog/tagcloud.html",
     ],
 }
 

--- a/examples/robots.txt
+++ b/examples/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+
+Sitemap: https://www.pymc.io/projects/examples/sitemap.xml

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
-ablog<0.11
+ablog>=0.11
 matplotlib
 myst-nb
 sphinx-codeautolink
@@ -10,3 +10,4 @@ sphinx-notfound-page
 sphinxcontrib-bibtex
 sphinxext-opengraph
 sphinxext-rediraffe
+sphinx-sitemap


### PR DESCRIPTION
This adds the sphinx-sitemap extension and a robots.txt file.

I have followed the adivse in https://sphinx-sitemap.readthedocs.io/en/latest/search-optimization.html but I don't really know what I'm doing, someone should really check the contents of both robots.txt and sitemap.xml: https://pymcio--639.org.readthedocs.build/projects/examples/en/639/sitemap.xml

<!-- readthedocs-preview pymc-examples start -->
----
📚 Documentation preview 📚: https://pymc-examples--639.org.readthedocs.build/en/639/

<!-- readthedocs-preview pymc-examples end -->