### PR TITLE
Add a mamba-compatible env file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,29 @@
+name: pymc-examples
+channels:
+- conda-forge
+- defaults
+dependencies:
+# Base dependencies
+- black
+- codespell
+- ipython
+- jupyterlab
+- notebook
+- pandas
+- pre-commit>=2.8.0
+- pymc
+- watermark
+# Extra dependencies for docs build
+- ablog>=0.11
+- matplotlib
+- myst-nb
+- sphinx-codeautolink
+- sphinx>=5
+- pymc-sphinx-theme==0.14
+- sphinx-copybutton
+- sphinx-design
+- sphinx-notfound-page
+- sphinxcontrib-bibtex
+- sphinxext-opengraph
+- sphinxext-rediraffe
+- sphinx-sitemap


### PR DESCRIPTION
There was no YML env file -- only `.txt` ones -- so I added one to make install with mamba seamless.
Ready to merge

<!-- readthedocs-preview pymc-examples start -->
----
📚 Documentation preview 📚: https://pymc-examples--652.org.readthedocs.build/en/652/

<!-- readthedocs-preview pymc-examples end -->