### PR TITLE
Enable $$ blocks inline via myst parser dmath_double_inline

### DIFF
--- a/examples/conf.py
+++ b/examples/conf.py
@@ -135,6 +135,7 @@ notfound_urls_prefix = "/projects/examples/en/latest/"
 
 # MyST config
 myst_enable_extensions = ["colon_fence", "deflist", "dollarmath", "amsmath", "substitution"]
+myst_dmath_double_inline = True
 citation_code = f"""
 ```bibtex
 @incollection{{citekey,


### PR DESCRIPTION
Fixes an issue in several notebook renders where `$$` blocks without a leading newline do not render properly.

### Before

![image](https://github.com/pymc-devs/pymc-examples/assets/1284973/1c1149d3-6d37-4855-81b0-7d5bea1ca78e)

### After

![image](https://github.com/pymc-devs/pymc-examples/assets/1284973/70db1ffc-3c9c-422c-b48c-0a925125c61e)

### Refs
- Myst docs: https://myst-parser.readthedocs.io/en/latest/configuration.html#id1:~:text=default%3A%20True)-,dmath_double_inline,-bool
- Changelog: https://myst-parser.readthedocs.io/en/latest/develop/_changelog.html#id19
- PR adding this option to myst: https://github.com/executablebooks/MyST-Parser/pull/369
- Relevant issue from related project: https://github.com/executablebooks/jupyter-book/issues/1181

Fixes #657


<!-- readthedocs-preview pymc-examples start -->
----
📚 Documentation preview 📚: https://pymc-examples--658.org.readthedocs.build/en/658/

<!-- readthedocs-preview pymc-examples end -->