### PR TITLE
Bound MyST NB to fix the compressed images

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,6 +1,6 @@
 ablog>=0.11
 matplotlib
-myst-nb
+myst-nb<=1.0.0
 sphinx-codeautolink
 sphinx>=5
 pymc-sphinx-theme==0.14

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,6 +1,6 @@
 ablog>=0.11
 matplotlib
-myst-nb<=1.0.0
+myst-nb!=1.1
 sphinx-codeautolink
 sphinx>=5
 pymc-sphinx-theme==0.14


### PR DESCRIPTION
The images of the gallery are being compressed by a change added in the latest release of MyST-NB. See https://github.com/pymc-labs/CausalPy/issues/327#issuecomment-2096256657 

This is a temporary fix until they resolve it (see https://github.com/pymc-labs/pymc-marketing/pull/667)

<!-- readthedocs-preview pymc-examples start -->
----
📚 Documentation preview 📚: https://pymc-examples--660.org.readthedocs.build/en/660/

<!-- readthedocs-preview pymc-examples end -->