### PR TITLE
Fix typo in API quickstart.

### DIFF
--- a/examples/introductory/api_quickstart.ipynb
+++ b/examples/introductory/api_quickstart.ipynb
@@ -207,7 +207,7 @@
     "- {ref}`pymc:api_distributions_discrete`\n",
     "- {ref}`pymc:api_distributions_multivariate`\n",
     "- {ref}`pymc:api_distributions_mixture`\n",
-    "- {ref}`pymc:api_distributions_rimeseries`\n",
+    "- {ref}`pymc:api_distributions_timeseries`\n",
     "- {ref}`pymc:api_distributions_censored`\n",
     "- {ref}`pymc:api_distributions_simulator`"
    ]


### PR DESCRIPTION
# Fix typo in API quickstart

<!-- Thank you so much for your PR to pymc-examples!

To make the merge process smoother we've provided some links and a checklist below.

We understand that PRs can sometimes be overwhelming, especially as the reviews start coming in.
Please let us know if the reviews are unclear or the recommended next step seems overly demanding,
if you would like help in addressing a reviewer's comments,
or if you have been waiting too long to hear back on your PR. -->

Since it's just a one character typo fix, wasn't sure if the following is applicable. Please lmk if it is and I will look into it.

+ [ ] Notebook follows style guide https://docs.pymc.io/en/latest/contributing/jupyter_style.html
+ [ ] PR description contains a link to the relevant issue:
  * a tracker one for existing notebooks (tracker issues have the "tracker id" label)
  * or a proposal one for new notebooks
+ [ ] Check the notebook is not excluded from any pre-commit check: https://github.com/pymc-devs/pymc-examples/blob/main/.pre-commit-config.yaml


### Helpful links
* https://github.com/pymc-devs/pymc-examples/blob/main/CONTRIBUTING.md


<!-- readthedocs-preview pymc-examples start -->
----
📚 Documentation preview 📚: https://pymc-examples--673.org.readthedocs.build/en/673/

<!-- readthedocs-preview pymc-examples end -->