### PR TITLE
Fix Minibatch alignment in Bayesian Neural Network example

### DIFF
--- a/examples/variational_inference/bayesian_neural_network_advi.ipynb
+++ b/examples/variational_inference/bayesian_neural_network_advi.ipynb
@@ -190,7 +190,7 @@
    },
    "outputs": [],
    "source": [
-    "def construct_nn(ann_input, ann_output):\n",
+    "def construct_nn():\n",
     "    n_hidden = 5\n",
     "\n",
     "    # Initialize random weights between each layer\n",
@@ -204,9 +204,14 @@
     "        \"train_cols\": np.arange(X_train.shape[1]),\n",
     "        \"obs_id\": np.arange(X_train.shape[0]),\n",
     "    }\n",
+    "    \n",
     "    with pm.Model(coords=coords) as neural_network:\n",
-    "        ann_input = pm.Data(\"ann_input\", X_train, dims=(\"obs_id\", \"train_cols\"))\n",
-    "        ann_output = pm.Data(\"ann_output\", Y_train, dims=\"obs_id\")\n",
+    "        # Define minibatch variables\n",
+    "        minibatch_x, minibatch_y = pm.Minibatch(X_train, Y_train, batch_size=50)\n",
+    "        \n",
+    "        # Define data variables using minibatches\n",
+    "        ann_input = pm.Data(\"ann_input\", minibatch_x, mutable=True, dims=(\"obs_id\", \"train_cols\"))\n",
+    "        ann_output = pm.Data(\"ann_output\", minibatch_y, mutable=True, dims=\"obs_id\")\n",
     "\n",
     "        # Weights from input to hidden layer\n",
     "        weights_in_1 = pm.Normal(\n",
@@ -231,13 +236,13 @@
     "            \"out\",\n",
     "            act_out,\n",
     "            observed=ann_output,\n",
-    "            total_size=Y_train.shape[0],  # IMPORTANT for minibatches\n",
+    "            total_size=X_train.shape[0],  # IMPORTANT for minibatches\n",
     "            dims=\"obs_id\",\n",
     "        )\n",
     "    return neural_network\n",
     "\n",
-    "\n",
-    "neural_network = construct_nn(X_train, Y_train)"
+    "# Create the neural network model\n",
+    "neural_network = construct_nn()\n"
    ]
   },
   {


### PR DESCRIPTION
# Fix Minibatch Alignment in Bayesian Neural Network Example

<!-- Thank you so much for your PR to pymc-examples!

To make the merge process smoother we've provided some links and a checklist below.

We understand that PRs can sometimes be overwhelming, especially as the reviews start coming in.
Please let us know if the reviews are unclear or the recommended next step seems overly demanding,
if you would like help in addressing a reviewer's comments,
or if you have been waiting too long to hear back on your PR. -->

+ [x] Notebook follows style guide https://docs.pymc.io/en/latest/contributing/jupyter_style.html
+ [x] PR description contains a link to the relevant issue:
  * Fixes issue #654
+ [x] Check the notebook is not excluded from any pre-commit check: https://github.com/pymc-devs/pymc-examples/blob/main/.pre-commit-config.yaml

### Issue
Fixes #654.

### Description
This PR addresses the issue where `Minibatch` variables for `X_train` and `Y_train` were created separately, causing potential misalignment in slices and thus random pairing of `X` with unrelated `y`.

### Changes Made
- Updated the code to create a single `Minibatch` for `X_train` and `Y_train` together, ensuring identical slices.
- Modified the construction of `ann_input` and `ann_output` using the unified `Minibatch` variables.
- Removed redundant parameters from the `construct_nn` function.
- Confirmed model architecture and initialization remain consistent.

### Impact
This change ensures that the model training process is more robust and prevents issues related to incorrect data alignment in minibatches.

### Helpful links
* https://github.com/pymc-devs/pymc-examples/blob/main/CONTRIBUTING.md
