### PR TITLE
Updates to Simpon's Paradox notebook

### DIFF
--- a/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
+++ b/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
@@ -288,9 +288,10 @@ Where $g_i$ is the group index for observation $i$. So the parameters $\beta_0$ 
 +++
 
 :::{note}
-We can also express this Model 2 in Wilkinson notation as `y ~ g + x:g`.
+We can also express this Model 2 in Wilkinson notation as `y ~ 0 + g + x:g`.
 
 * The `g` term captures the group specific intercept $\beta_0[g_i]$ parameters.
+* The `0` means we do not have a global intercept term, leaving the group specific intercepts to be the only intercepts.
 * The `x:g` term captures group specific slope $\beta_1[g_i]$ parameters.
 :::
 

--- a/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
+++ b/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
@@ -433,24 +433,13 @@ ax[0].set(
 
 ## Model 3: Partial pooling model
 
-Model 3 assumes the same causal DAG as model 2 (see above). However, we can go further and incorporate more knowledge about the structure of our data. Rather than treating each group as entirely independent, we can use our knowledge that these groups are drawn from a population-level distribution. We could formalise this as saying that the group-level slopes and intercepts are modeled as deflections from a population-level slopes and intercepts, respectively.
+Model 3 assumes the same causal DAG as model 2 (see above). However, we can go further and incorporate more knowledge about the structure of our data. Rather than treating each group as entirely independent, we can use our knowledge that these groups are drawn from a population-level distribution. We could formalise this as saying that the group-level slopes and intercepts are modeled as deflections from a population-level slope and intercept, respectively.
 
 +++
 
 And we could describe this model mathematically as:
 
 $$
-% \begin{aligned}
-% \beta_0 &\sim \text{Normal}(0, 1) \\
-% \beta_1 &\sim \text{Normal}(0, 1) \\
-% p_{0\sigma}, p_{1\sigma} &\sim \text{Gamma}(2, 2) \\
-% \vec{u_0} &\sim \text{Normal}(0, p_{0\sigma}) \\ 
-% \vec{u_1} &\sim \text{Normal}(0, p_{1\sigma}) \\ 
-% \sigma &\sim \text{Gamma}(2, 2) \\
-% \mu_i &= \overbrace{\Big( \underbrace{\beta_0}_{\text{pop}} + \underbrace{\vec{u_0}[g_i]}_{\text{group}} \Big)}^{\text{intercept}} 
-%          + \overbrace{\Big( \underbrace{\beta_1[g_i] \cdot x_i}_{\text{pop}} + \underbrace{\vec{u_1}[g_i] \cdot u_i }_{\text{group}}\Big) }^{\text{slope}}\\
-% y_i &\sim \text{Normal}(\mu_i, \sigma)
-% \end{aligned}
 \begin{aligned}
 \beta_0 &\sim \text{Normal}(0, 1), \\
 \beta_1 &\sim \text{Normal}(0, 1), \\
@@ -467,7 +456,7 @@ p_{0\sigma}, p_{1\sigma} &\sim \text{Gamma}(2, 2), \\
       + \overbrace{
             \left( 
                 \underbrace{\beta_1 \cdot x_i}_{\text{pop}} 
-                + \underbrace{\vec{u_1}[g_i] \cdot u_i}_{\text{group}} 
+                + \underbrace{\vec{u_1}[g_i] \cdot x_i}_{\text{group}} 
             \right)
          }^{\text{slope}}, \\
 y_i &\sim \text{Normal}(\mu_i, \sigma).

--- a/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
+++ b/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
@@ -116,7 +116,7 @@ with pm.Model() as linear_regression:
     sigma = pm.HalfCauchy("sigma", beta=2)
     β0 = pm.Normal("β0", 0, sigma=5)
     β1 = pm.Normal("β1", 0, sigma=5)
-    x = pm.MutableData("x", data.x, dims="obs_id")
+    x = pm.Data("x", data.x, dims="obs_id")
     μ = pm.Deterministic("μ", β0 + β1 * x, dims="obs_id")
     pm.Normal("y", mu=μ, sigma=sigma, observed=data.y, dims="obs_id")
 ```
@@ -238,8 +238,8 @@ with pm.Model(coords=coords) as ind_slope_intercept:
     β0 = pm.Normal("β0", 0, sigma=5, dims="group")
     β1 = pm.Normal("β1", 0, sigma=5, dims="group")
     # Data
-    x = pm.MutableData("x", data.x, dims="obs_id")
-    g = pm.MutableData("g", data.group_idx, dims="obs_id")
+    x = pm.Data("x", data.x, dims="obs_id")
+    g = pm.Data("g", data.group_idx, dims="obs_id")
     # Linear model
     μ = pm.Deterministic("μ", β0[g] + β1[g] * x, dims="obs_id")
     # Define likelihood
@@ -395,8 +395,8 @@ with pm.Model(coords=coords) as hierarchical:
         β1 = pm.Normal("β1", slope_mu, sigma=slope_sigma, dims="group")
 
     # Data
-    x = pm.MutableData("x", data.x, dims="obs_id")
-    g = pm.MutableData("g", data.group_idx, dims="obs_id")
+    x = pm.Data("x", data.x, dims="obs_id")
+    g = pm.Data("g", data.group_idx, dims="obs_id")
     # Linear model
     μ = pm.Deterministic("μ", β0[g] + β1[g] * x, dims="obs_id")
     # Define likelihood

--- a/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
+++ b/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
@@ -133,7 +133,7 @@ with linear_regression:
 ```
 
 ```{code-cell} ipython3
-az.plot_trace(idata, filter_vars="regex", var_names=["~μ"]);
+az.plot_trace(idata, var_names=["~μ"]);
 ```
 
 ### Visualisation
@@ -256,7 +256,7 @@ pm.model_to_graphviz(ind_slope_intercept)
 with ind_slope_intercept:
     idata = pm.sample()
 
-az.plot_trace(idata, filter_vars="regex", var_names=["~μ"]);
+az.plot_trace(idata, var_names=["~μ"]);
 ```
 
 ### Visualisation
@@ -413,7 +413,7 @@ pm.model_to_graphviz(hierarchical)
 with hierarchical:
     idata = pm.sample(tune=2000, target_accept=0.99)
 
-az.plot_trace(idata, filter_vars="regex", var_names=["~μ"]);
+az.plot_trace(idata, var_names=["~μ"]);
 ```
 
 ### Visualise

--- a/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
+++ b/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
@@ -25,7 +25,7 @@ kernelspec:
 
 ![](https://upload.wikimedia.org/wikipedia/commons/f/fb/Simpsons_paradox_-_animation.gif)
 
-This paradox can be resolved by assuming a causal DAG which includes how the main predictor variable _and_ group membership influence the outcome variable. We demonstrate an example where we _don't_ incorporate group membership (so our causal DAG is wrong, or in other words out model is misspecified). We then show 2 wayes to resolve this by including group membership as causal influence upon the outcome variable. This is shown in an unpooled model (which we could also call a fixed effects model) and a hierarchical model (which we could also call a mixed effects model).
+This paradox can be resolved by assuming a causal DAG which includes how the main predictor variable _and_ group membership influence the outcome variable. We demonstrate an example where we _don't_ incorporate group membership (so our causal DAG is wrong, or in other words our model is misspecified). We then show 2 wayes to resolve this by including group membership as causal influence upon the outcome variable. This is shown in an unpooled model (which we could also call a fixed effects model) and a hierarchical model (which we could also call a mixed effects model).
 
 ```{code-cell} ipython3
 import arviz as az

--- a/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
+++ b/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
@@ -513,7 +513,7 @@ ax[2].set(
 )
 ```
 
-The panel on the right shows the posterior group level posterior of the slope and intercept parameters in black. This particular visualisation is a little unclear however, so we can just plot the marginal distribution below to see how much belief we have in the slope being less than zero.
+The panel on the right shows the posterior group level posterior of the slope and intercept parameters as a contour plot. We can also just plot the marginal distribution below to see how much belief we have in the slope being less than zero.
 
 ```{code-cell} ipython3
 :tags: [hide-input]

--- a/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
+++ b/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
@@ -439,8 +439,8 @@ And we could describe this model mathematically as:
 
 $$
 \begin{aligned}
-p_{0\mu}, p_{1\mu} &= \text{Normal}(0, 1) \\
-p_{0\sigma}, p_{1\sigma} &= \text{Gamma}(2, 2) \\
+p_{0\mu}, p_{1\mu} &\sim \text{Normal}(0, 1) \\
+p_{0\sigma}, p_{1\sigma} &\sim \text{Gamma}(2, 2) \\
 \vec{\beta_0} &\sim \text{Normal}(p_{0\mu}, p_{0\sigma}) \\
 \vec{\beta_1} &\sim \text{Normal}(p_{1\mu}, p_{1\sigma}) \\
 \sigma &\sim \text{Gamma}(2, 2) \\

--- a/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
+++ b/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
@@ -258,7 +258,7 @@ ax.set(title="Model 1 strongly suggests a positive slope", xlabel=r"$\beta_1$");
 
 ## Model 2: Unpooled regression
 
-We will use the same data in this analysis, but this time we will use our knowledge that data come from groups. From a causal perspective we are exploring the notion that both $x$ and $y$ are influenced by group membership. This can be shown in the causal DAG below.
+We will use the same data in this analysis, but this time we will use our knowledge that data come from groups. From a causal perspective we are exploring the notion that both $x$ and $y$ are influenced by group membership. This can be shown in the causal directed acyclic graph ([DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph)) below.
 
 ```{code-cell} ipython3
 :tags: [hide-input]

--- a/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
+++ b/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
@@ -245,7 +245,7 @@ plot(idata1)
 
 The plot on the left shows the data and the posterior of the **conditional mean**. For a given $x$, we get a posterior distribution of the model (i.e. of $\mu$).
 
-The plot in the middle shows the **posterior predictive distribution**, which gives a statement about the data we expect to see. Intuitively, this can be understood as not only incorporating what we know of the model (left plot) but also what we know about the distribution of error.
+The plot in the middle shows the conditional **posterior predictive distribution**, which gives a statement about the data we expect to see. Intuitively, this can be understood as not only incorporating what we know of the model (left plot) but also what we know about the distribution of error.
 
 The plot on the right shows our posterior beliefs in **parameter space**.
 

--- a/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
+++ b/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
@@ -5,9 +5,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: pymc_env
+  display_name: Python 3
   language: python
-  name: pymc_env
+  name: python3
 ---
 
 (GLM-simpsons-paradox)=
@@ -34,6 +34,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pymc as pm
+import seaborn as sns
 import xarray as xr
 ```
 
@@ -82,16 +83,7 @@ display(data)
 And we can visualise this as below.
 
 ```{code-cell} ipython3
-:tags: [hide-input]
-
-for i, group in enumerate(group_list):
-    plt.scatter(
-        data.query(f"group_idx=={i}").x,
-        data.query(f"group_idx=={i}").y,
-        color=f"C{i}",
-        label=f"{group}",
-    )
-plt.legend(title="group");
+sns.scatterplot(data=data, x="x", y="y", hue="group");
 ```
 
 The rest of the notebook will cover different ways that we can analyse this data using linear models.
@@ -488,7 +480,7 @@ with hierarchical:
     idata = pm.sample(tune=4000, target_accept=0.99, random_seed=rng)
 ```
 
-:::{note}
+:::{caution}
 Note that despite having a longer tune period and increased `target_accept`, this model can still generate a low number of divergent samples. If the reader is interested, you can explore the a "reparameterisation trick" is used by setting the flag `non_centered=True`. See the blog post [Why hierarchical models are awesome, tricky, and Bayesian](https://twiecki.io/blog/2017/02/08/bayesian-hierchical-non-centered/) by Thomas Wiecki for more information on this.
 :::
 

--- a/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
+++ b/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
@@ -41,7 +41,8 @@ import xarray as xr
 ```{code-cell} ipython3
 %config InlineBackend.figure_format = 'retina'
 az.style.use("arviz-darkgrid")
-plt.rcParams["figure.figsize"] = [12, 6]
+figsize = [12, 4]
+plt.rcParams["figure.figsize"] = figsize
 rng = np.random.default_rng(1234)
 ```
 
@@ -81,7 +82,8 @@ display(data)
 And we can visualise this as below.
 
 ```{code-cell} ipython3
-sns.scatterplot(data=data, x="x", y="y", hue="group");
+fig, ax = plt.subplots(figsize=(8, 6))
+sns.scatterplot(data=data, x="x", y="y", hue="group", ax=ax);
 ```
 
 The rest of the notebook will cover different ways that we can analyse this data using linear models.
@@ -417,7 +419,7 @@ The plot below takes a closer look at the group level slope parameters.
 ```{code-cell} ipython3
 :tags: [hide-input]
 
-ax = az.plot_forest(idata2.posterior["β1"], combined=True, figsize=(12, 4))
+ax = az.plot_forest(idata2.posterior["β1"], combined=True, figsize=figsize)
 ax[0].set(
     title="Model 2 suggests negative slopes for each group", xlabel=r"$\beta_1$", ylabel="Group"
 );
@@ -628,10 +630,8 @@ The panel on the right shows the group level posterior of the slope and intercep
 ```{code-cell} ipython3
 :tags: [hide-input]
 
-az.plot_forest(idata2.posterior["β1"], combined=True)
-ax[0].set(
-    title="Model 3 suggests negative slopes for each group", xlabel=r"$\beta_1$", ylabel="Group"
-);
+ax = az.plot_forest(idata2.posterior["β1"], combined=True, figsize=figsize)[0]
+ax.set(title="Model 3 suggests negative slopes for each group", xlabel=r"$\beta_1$", ylabel="Group");
 ```
 
 ## Summary

--- a/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
+++ b/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
@@ -420,6 +420,8 @@ plot(idata2);
 In contrast to Model 1, when we consider groups we can see that now the evidence points toward _negative_ relationships between $x$ and $y$.
 
 ```{code-cell} ipython3
+:tags: [hide-input]
+
 ax = az.plot_forest(idata2.posterior["β1"], combined=True, figsize=(12, 4))
 ax[0].set(
     title="Model 2 suggests negative slopes for each group", xlabel=r"$\beta_1$", ylabel="Group"
@@ -577,7 +579,7 @@ sns.kdeplot(
 ax[2].set(xlim=[-2, 1], ylim=[-5, 5]);
 ```
 
-The panel on the right shows the posterior group level posterior of the slope and intercept parameters as a contour plot. We can also just plot the marginal distribution below to see how much belief we have in the slope being less than zero.
+The panel on the right shows the group level posterior of the slope and intercept parameters as a contour plot. We can also just plot the marginal distribution below to see how much belief we have in the slope being less than zero.
 
 ```{code-cell} ipython3
 :tags: [hide-input]

--- a/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
+++ b/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
@@ -21,17 +21,11 @@ kernelspec:
 
 +++
 
-This notebook covers:
-- [Simpson's Paradox](https://en.wikipedia.org/wiki/Simpson%27s_paradox) and its resolution through mixed or hierarchical models. This is a situation where there might be a negative relationship between two variables within a group, but when data from multiple groups are combined, that relationship may disappear or even reverse sign. The gif below (from the [Simpson's Paradox](https://en.wikipedia.org/wiki/Simpson%27s_paradox) Wikipedia page) demonstrates this very nicely.
-- How to build linear regression models, starting with linear regression, moving up to hierarchical linear regression. Simpon's paradox is a nice motivation for why we might want to do this - but of course we should aim to build models which incorporate as much as our knowledge about the structure of the data (e.g. it's nested nature) as possible.
-- Use of `pm.Data` containers to facilitate posterior prediction at different $x$ values with the same model.
-- Providing array dimensions (see `coords`) to models to help with shape problems. This involves the use of [xarray](http://xarray.pydata.org/) and is quite helpful in multi-level / hierarchical models.
-- Differences between posteriors and posterior predictive distributions.
-- How to visualise models in data space and parameter space, using a mixture of [ArviZ](https://arviz-devs.github.io/arviz/) and [matplotlib](https://matplotlib.org/).
-
-+++
+[Simpson's Paradox](https://en.wikipedia.org/wiki/Simpson%27s_paradox) describes a situation where there might be a negative relationship between two variables within a group, but when data from multiple groups are combined, that relationship may disappear or even reverse sign. The gif below (from the [Simpson's Paradox](https://en.wikipedia.org/wiki/Simpson%27s_paradox) Wikipedia page) demonstrates this very nicely.
 
 ![](https://upload.wikimedia.org/wikipedia/commons/f/fb/Simpsons_paradox_-_animation.gif)
+
+This paradox can be resolved by assuming a causal DAG which includes how the main predictor variable _and_ group membership influence the outcome variable. We demonstrate an example where we _don't_ incorporate group membership (so our causal DAG is wrong, or in other words out model is misspecified). We then show 2 wayes to resolve this by including group membership as causal influence upon the outcome variable. This is shown in an unpooled model (which we could also call a fixed effects model) and a hierarchical model (which we could also call a mixed effects model).
 
 ```{code-cell} ipython3
 import arviz as az

--- a/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
+++ b/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
@@ -433,12 +433,12 @@ And we could describe this model mathematically as:
 
 $$
 \begin{aligned}
-\beta_0 &\sim \text{Normal}(0, 5), \\
-\beta_1 &\sim \text{Normal}(0, 5), \\
-p_{0\sigma}, p_{1\sigma} &\sim \text{Gamma}(2, 2), \\
-\vec{u_0} &\sim \text{Normal}(0, p_{0\sigma}), \\ 
-\vec{u_1} &\sim \text{Normal}(0, p_{1\sigma}), \\ 
-\sigma &\sim \text{Gamma}(2, 2), \\
+\beta_0 &\sim \text{Normal}(0, 5) \\
+\beta_1 &\sim \text{Normal}(0, 5) \\
+p_{0\sigma}, p_{1\sigma} &\sim \text{Gamma}(2, 2) \\
+\vec{u_0} &\sim \text{Normal}(0, p_{0\sigma}) \\ 
+\vec{u_1} &\sim \text{Normal}(0, p_{1\sigma}) \\ 
+\sigma &\sim \text{Gamma}(2, 2) \\
 \mu_i &= \overbrace{
             \left( 
                 \underbrace{\beta_0}_{\text{pop}} 
@@ -450,8 +450,8 @@ p_{0\sigma}, p_{1\sigma} &\sim \text{Gamma}(2, 2), \\
                 \underbrace{\beta_1 \cdot x_i}_{\text{pop}} 
                 + \underbrace{\vec{u_1}[g_i] \cdot x_i}_{\text{group}} 
             \right)
-         }^{\text{slope}}, \\
-y_i &\sim \text{Normal}(\mu_i, \sigma).
+         }^{\text{slope}} \\
+y_i &\sim \text{Normal}(\mu_i, \sigma)
 \end{aligned}
 $$
 

--- a/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
+++ b/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
@@ -544,8 +544,9 @@ If you are interested in learning more, there are a number of other [PyMC exampl
 ## Authors
 * Authored by [Benjamin T. Vincent](https://github.com/drbenvincent) in July 2021
 * Updated by [Benjamin T. Vincent](https://github.com/drbenvincent) in April 2022
-* Updated by Benjamin T. Vincent in February 2023 to run on PyMC v5
+* Updated by [Benjamin T. Vincent](https://github.com/drbenvincent) in February 2023 to run on PyMC v5
 * Updated to use `az.extract` by [Benjamin T. Vincent](https://github.com/drbenvincent) in February 2023 ([pymc-examples#522](https://github.com/pymc-devs/pymc-examples/pull/522))
+* Updated by [Benjamin T. Vincent](https://github.com/drbenvincent) in September 2024
 
 +++
 

--- a/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
+++ b/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
@@ -98,7 +98,7 @@ The rest of the notebook will cover different ways that we can analyse this data
 
 +++
 
-## Model 1: Basic linear regression
+## Model 1: Pooled regression
 
 First we examine the simplest model - plain linear regression which pools all the data and has no knowledge of the group/multi-level structure of the data.
 
@@ -245,7 +245,7 @@ One of the clear things about this analysis is that we have credible evidence th
 
 +++
 
-## Model 2: Independent slopes and intercepts model
+## Model 2: Unpooled regression
 
 We will use the same data in this analysis, but this time we will use our knowledge that data come from groups. From a causal perspective we are exploring the notion that both $x$ and $y$ are influenced by group membership. This can be shown in the causal DAG below.
 
@@ -409,7 +409,7 @@ In contrast to plain regression model (Model 1), when we model on the group leve
 
 +++
 
-## Model 3: Hierarchical regression
+## Model 3: Partial pooling (hierarchical) model
 
 Model 3 assumes the same causal DAG as model 2 (see above). However, we can go further and incorporate more knowledge about the structure of our data. Rather than treating each group as entirely independent, we can use our knowledge that these groups are drawn from a population-level distribution. 
 

--- a/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
+++ b/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
@@ -25,7 +25,7 @@ kernelspec:
 
 ![](https://upload.wikimedia.org/wikipedia/commons/f/fb/Simpsons_paradox_-_animation.gif)
 
-This paradox can be resolved by assuming a causal DAG which includes how the main predictor variable _and_ group membership influence the outcome variable. We demonstrate an example where we _don't_ incorporate group membership (so our causal DAG is wrong, or in other words our model is misspecified). We then show 2 wayes to resolve this by including group membership as causal influence upon the outcome variable. This is shown in an unpooled model (which we could also call a fixed effects model) and a hierarchical model (which we could also call a mixed effects model).
+This paradox can be resolved by assuming a causal DAG which includes how the main predictor variable _and_ group membership influence the outcome variable. We demonstrate an example where we _don't_ incorporate group membership (so our causal DAG is wrong, or in other words our model is misspecified). We then show 2 ways to resolve this by including group membership as causal influence upon the outcome variable. This is shown in an unpooled model (which we could also call a fixed effects model) and a hierarchical model (which we could also call a mixed effects model).
 
 ```{code-cell} ipython3
 import arviz as az

--- a/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
+++ b/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
@@ -443,9 +443,7 @@ This model could also be called a partial pooling model.
 
 +++
 
-:::{admonition} **Notes**
-:class: note
-
+:::{note}
 The hierarchical model we are considering contains a simplification in that the population level slope and intercept are assumed to be independent. It is possible to relax this assumption and model any correlation between these parameters by using a multivariate normal distribution.
 
 In one sense this move from Model 2 to Model 3 can be seen as adding parameters, and therefore increasing model complexity. However, in another sense, adding this knowledge about the nested structure of the data actually provides a constraint over parameter space.
@@ -496,9 +494,7 @@ with hierarchical:
     idata = pm.sample(tune=4000, target_accept=0.99, random_seed=rng)
 ```
 
-:::{admonition} **Divergences**
-:class: note
-
+:::{note}
 Note that despite having a longer tune period and increased `target_accept`, this model can still generate a low number of divergent samples. If the reader is interested, you can explore the a "reparameterisation trick" is used by setting the flag `non_centered=True`. See the blog post [Why hierarchical models are awesome, tricky, and Bayesian](https://twiecki.io/blog/2017/02/08/bayesian-hierchical-non-centered/) by Thomas Wiecki for more information on this.
 :::
 

--- a/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
+++ b/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
@@ -119,7 +119,7 @@ $$
 
 +++
 
-:::{info}
+:::{note}
 We can also express Model 1 in Wilkinson notation as `y ~ 1 + x` which is equivalent to `y ~ x` as the intercept is included by default.
 
 * The `1` term corresponds to the intercept term $\beta_0$.
@@ -283,7 +283,7 @@ Where $g_i$ is the group index for observation $i$. So the parameters $\beta_0$ 
 
 +++
 
-:::{info}
+:::{note}
 We can also express this Model 2 in Wilkinson notation as `y ~ g + x:g`.
 
 * The `g` term captures the group specific intercept $\beta_0[g_i]$ parameters.
@@ -450,7 +450,7 @@ This model could also be called a partial pooling model.
 
 +++
 
-:::{info}
+:::{note}
 We can also express this Model 3 in Wilkinson notation as `1 + x + (1 + x | g)`.
 
 * The `1` captures the global intercept, $\mathrm{Normal}(p_{0\mu}, p_{0\sigma})$.
@@ -462,10 +462,14 @@ We can also express this Model 3 in Wilkinson notation as `1 + x + (1 + x | g)`.
 
 +++
 
-:::{note}
-The hierarchical model we are considering contains a simplification in that the population level slope and intercept are assumed to be independent. It is possible to relax this assumption and model any correlation between these parameters by using a multivariate normal distribution.
+:::{seealso}
+The hierarchical model we are considering contains a simplification in that the population level slope and intercept are assumed to be independent. It is possible to relax this assumption and model any correlation between these parameters by using a multivariate normal distribution. See the {ref}`lkj_prior_for_multivariate_normal` notebook for more details.
+:::
 
-In one sense this move from Model 2 to Model 3 can be seen as adding parameters, and therefore increasing model complexity. However, in another sense, adding this knowledge about the nested structure of the data actually provides a constraint over parameter space.
++++
+
+:::{seealso}
+In one sense this move from Model 2 to Model 3 can be seen as adding parameters, and therefore increasing model complexity. However, in another sense, adding this knowledge about the nested structure of the data actually provides a constraint over parameter space. It would be possible to engage in model comparison to arbitrate between these models - see for example the {ref}`GLM-model-selection` notebook for more details.
 :::
 
 +++

--- a/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
+++ b/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
@@ -518,7 +518,7 @@ y_i &\sim \text{Normal}(\mu_i, \sigma)
 \end{aligned}
 $$
 
-where $\vec{\beta_0}$ and $\vec{\beta_1}$ are the group-level parameters. These group level parameters can be though of as being sampled from population level intercept distribution $\text{Normal}(p_{0\mu}, p_{0\sigma})$ and population level slope distribution $\text{Normal}(p_{1\mu}, p_{1\sigma})$.
+where $\vec{\beta_0}$ and $\vec{\beta_1}$ are the group-level parameters. These group level parameters can be thought of as being sampled from population level intercept distribution $\text{Normal}(p_{0\mu}, p_{0\sigma})$ and population level slope distribution $\text{Normal}(p_{1\mu}, p_{1\sigma})$. So these distributions would represent what we might expect to observe for some as yet unobserved group.
 
 However, this formulation of the model does not so neatly map on to the Wilkinson notation. For this reason, we have chosen to present the model in the form given above. For an interesting discussion on this topic, see [Discussion #808](https://github.com/bambinos/bambi/discussions/808) in the [`bambi`](https://github.com/bambinos/bambi) repository.
 :::
@@ -621,18 +621,6 @@ def plot(idata):
 
 
 ax = plot(idata3)
-
-# # add a KDE countour plot of the population level parameters
-# sns.kdeplot(
-#     x=az.extract(idata3, var_names="pop_slope"),
-#     y=az.extract(idata3, var_names="pop_intercept"),
-#     thresh=0.1,
-#     levels=5,
-#     color="k",
-#     ax=ax[2],
-# )
-
-# ax[2].set(xlim=[-2, 1], ylim=[-5, 5]);
 ```
 
 The panel on the right shows the group level posterior of the slope and intercept parameters as a contour plot. We can also just plot the marginal distribution below to see how much belief we have in the slope being less than zero.
@@ -640,17 +628,10 @@ The panel on the right shows the group level posterior of the slope and intercep
 ```{code-cell} ipython3
 :tags: [hide-input]
 
-fig, ax = plt.subplots(1, 2)
-
-az.plot_forest(idata2.posterior["β1"], combined=True, ax=ax[0])
+az.plot_forest(idata2.posterior["β1"], combined=True)
 ax[0].set(
     title="Model 3 suggests negative slopes for each group", xlabel=r"$\beta_1$", ylabel="Group"
-)
-
-# az.plot_posterior(idata3.posterior["pop_slope"], ref_val=0, ax=ax[1])
-# ax[1].set(
-#     title="Population level slope parameter", xlabel=r"$\text{Normal}(p_{1\mu}, p_{1\sigma})$"
-# );
+);
 ```
 
 ## Summary

--- a/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
+++ b/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
@@ -554,7 +554,7 @@ If you are interested in learning more, there are a number of other [PyMC exampl
 
 ```{code-cell} ipython3
 %load_ext watermark
-%watermark -n -u -v -iv -w -p pytensor,aeppl
+%watermark -n -u -v -iv -w -p pytensor,xarray
 ```
 
 :::{include} ../page_footer.md

--- a/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
+++ b/examples/generalized_linear_models/GLM-simpsons-paradox.myst.md
@@ -618,11 +618,13 @@ plt.title("Population level slope parameter");
 ```
 
 ## Summary
-Using Simpson's paradox, we've walked through 3 different models. The first is a simple linear regression which treats all the data as coming from one group. We saw that this lead us to believe the regression slope was positive.
+Using Simpson's paradox, we've walked through 3 different models. The first is a simple linear regression which treats all the data as coming from one group. This amounts to a causal DAG asserting that $x$ causally influences $y$ and $\text{group}$ was ignored (i.e. assumed to be causally unrelated to $x$ or $y$). We saw that this lead us to believe the regression slope was positive.
 
-While that is not necessarily wrong, it is paradoxical when we see that the regression slopes for the data _within_ a group is negative. We saw how to apply separate regressions for data in each group in the second model.
+While that is not necessarily wrong, it is paradoxical when we see that the regression slopes for the data _within_ a group is negative. 
 
-The third and final model added a layer to the hierarchy, which captures our knowledge that each of these groups are sampled from an overall population. This added the ability to make inferences not only about the regression parameters at the group level, but also at the population level. The final plot shows our posterior over this population level slope parameter from which we believe the groups are sampled from.
+This paradox is resolved by updating our causal DAG to include the group variable. This is what we did in the second and third models. Model 2 was an unpooled model where we essentially fit separate regressions for each group.
+
+Model 3 assumed the same causal DAG, but adds the knowledge that each of these groups are sampled from an overall population. This added the ability to make inferences not only about the regression parameters at the group level, but also at the population level.
 
 If you are interested in learning more, there are a number of other [PyMC examples](http://docs.pymc.io/nb_examples/index.html) covering hierarchical modelling and regression topics.
 

--- a/examples/howto/LKJ.ipynb
+++ b/examples/howto/LKJ.ipynb
@@ -6,6 +6,7 @@
     "id": "XShKDkNir2PX"
    },
    "source": [
+    "(lkj_prior_for_multivariate_normal)=\n",
     "# LKJ Cholesky Covariance Priors for Multivariate Normal Models"
    ]
   },

--- a/examples/howto/LKJ.myst.md
+++ b/examples/howto/LKJ.myst.md
@@ -12,6 +12,7 @@ kernelspec:
 
 +++ {"id": "XShKDkNir2PX"}
 
+(lkj_prior_for_multivariate_normal)=
 # LKJ Cholesky Covariance Priors for Multivariate Normal Models
 
 +++ {"id": "QxSKBbjKr2PZ"}


### PR DESCRIPTION
This PR updates the Simpon's Paradox notebook in a number of ways:
* `MutableData` -> `Data`
* Updated watermark based on the current style guide
* Added mathematical descriptions of the models
* Improved the hierarchical model. Switched from non-centred to regular parameterisation which gives a simpler graphviz which is more closely aligned to the model maths
* Increased the causal language and have included causal DAGs
* Added `rng` to sampling functions for increased reproducibility
* Significantly simplified potting code
* Added Wilkinson notation (and explanation) for each model. _Hopefully this is correct, but I am not 100% sure._
* Adds a missing notebook reference to the LKJ notebook because I reference to it from this one.
* Added some more data visualisation 
* All models now have a fully pooled observation noise parameter for simplicity.

---

+ [X] Notebook follows style guide https://docs.pymc.io/en/latest/contributing/jupyter_style.html
+ [ ] PR description contains a link to the relevant issue:
  * a tracker one for existing notebooks (tracker issues have the "tracker id" label)
  * or a proposal one for new notebooks
+ [X] Check the notebook is not excluded from any pre-commit check: https://github.com/pymc-devs/pymc-examples/blob/main/.pre-commit-config.yaml

Note: This PR is not related to an issue, I just decided to make these updates in the absence of an issue.

<!-- readthedocs-preview pymc-examples start -->
----
📚 Documentation preview 📚: https://pymc-examples--697.org.readthedocs.build/en/697/

<!-- readthedocs-preview pymc-examples end -->