### PR TITLE
Add tutorial demonstrating vector-valued random variables (Fixes #4007)

### DIFF
--- a/examples/howto/vector_variables.ipynb
+++ b/examples/howto/vector_variables.ipynb
@@ -1,0 +1,753 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "bb46210d",
+   "metadata": {},
+   "source": [
+    "# Demonstrating Vector Variables in PyMC\n",
+    "\n",
+    "This tutorial shows how to work with **vector-valued random variables** in PyMC,\n",
+    "using a simple example with several groups of data that share a common\n",
+    "structure but have different means (and optionally different standard\n",
+    "deviations).\n",
+    "\n",
+    "We will:\n",
+    "\n",
+    "1. Simulate data from multiple groups.  \n",
+    "2. Build a PyMC model with vector parameters `mu` (means) and `sigma`.  \n",
+    "3. Use indexing to connect each observation to the right group parameter.  \n",
+    "4. Sample from the posterior and inspect the results.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8384f0b1",
+   "metadata": {},
+   "source": [
+    "## 1. Setup\n",
+    "\n",
+    "We start by importing the libraries we need and fixing a random seed for\n",
+    "reproducibility."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a835935a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING (pytensor.configdefaults): g++ not available, if using conda: `conda install gxx`\n",
+      "WARNING (pytensor.configdefaults): g++ not detected!  PyTensor will be unable to compile C-implementations and will default to Python. Performance may be severely degraded. To remove this warning, set PyTensor flags cxx to an empty string.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import arviz as az\n",
+    "import numpy as np\n",
+    "import pymc as pm\n",
+    "\n",
+    "RANDOM_SEED = 123\n",
+    "rng = np.random.default_rng(RANDOM_SEED)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "fcadcb1d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "# Configure PyTensor to use g++ compiler if available, otherwise suppress warning\n",
+    "import pytensor\n",
+    "\n",
+    "# Try to find g++ compiler\n",
+    "gxx_paths = [\n",
+    "    r\"C:\\Users\\mrcle\\miniconda3\\Library\\bin\\x86_64-w64-mingw32-g++.exe\",\n",
+    "    \"g++\",  # Try system g++ if in PATH\n",
+    "]\n",
+    "\n",
+    "gxx_found = None\n",
+    "for path in gxx_paths:\n",
+    "    if path == \"g++\":\n",
+    "        # Check if g++ is in PATH\n",
+    "        import shutil\n",
+    "\n",
+    "        if shutil.which(\"g++\"):\n",
+    "            gxx_found = \"g++\"\n",
+    "            break\n",
+    "    elif os.path.exists(path):\n",
+    "        gxx_found = path\n",
+    "        break\n",
+    "\n",
+    "if gxx_found:\n",
+    "    pytensor.config.cxx = gxx_found\n",
+    "    print(f\"PyTensor configured to use: {gxx_found}\")\n",
+    "else:\n",
+    "    # Suppress warning if compiler not found\n",
+    "    pytensor.config.cxx = \"\"\n",
+    "    print(\n",
+    "        \"g++ compiler not found. PyTensor will use Python fallback (slower but works fine for examples).\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87dcae3e",
+   "metadata": {},
+   "source": [
+    "## 2. Simulate grouped data\n",
+    "\n",
+    "We create:\n",
+    "\n",
+    "- `num_groups`: how many groups we have.  \n",
+    "- `group_size`: how many observations per group.  \n",
+    "- `sigma_true`: shared standard deviation of the observation noise.  \n",
+    "- `mu_true`: a vector of true group means (used only to generate fake data).\n",
+    "\n",
+    "We then build:\n",
+    "\n",
+    "- `data`: stacked observations from all groups.  \n",
+    "- `data_labels`: an integer label (0, 1, ..., `num_groups-1`) telling us\n",
+    "  which group each observation belongs to."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "041b9873",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([-1.91745688, -3.13102432, -1.95260845, -2.81115613, -2.81694979,\n",
+       "        -2.39739336, -4.02049108, -1.30239457, -3.16565035, -1.49429126]),\n",
+       " array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "num_groups = 5\n",
+    "group_size = 200\n",
+    "sigma_true = 1.0\n",
+    "\n",
+    "# True means for each group (just for simulation, not known to the model)\n",
+    "mu_true = rng.normal(loc=np.linspace(-2, 2, num_groups), scale=0.5, size=num_groups)\n",
+    "\n",
+    "# Simulate data: for each group, draw `group_size` points\n",
+    "data_per_group = [rng.normal(loc=mu, scale=sigma_true, size=group_size) for mu in mu_true]\n",
+    "data = np.concatenate(data_per_group)\n",
+    "\n",
+    "# Integer labels telling which group each observation belongs to\n",
+    "data_labels = np.concatenate(\n",
+    "    [np.full(group_size, group_id) for group_id in range(num_groups)]\n",
+    ").astype(int)\n",
+    "\n",
+    "data[:10], data_labels[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a50caa9",
+   "metadata": {},
+   "source": [
+    "`data` is a 1D array of length `num_groups * group_size`.\n",
+    "\n",
+    "`data_labels` is a 1D integer array of the same length, where each element is\n",
+    "the group index (from 0 to `num_groups - 1`) for the corresponding observation.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69e4fe50",
+   "metadata": {},
+   "source": [
+    "## 3. Building the PyMC model with vector variables\n",
+    "\n",
+    "Key idea: instead of defining separate scalar parameters for each group, we\n",
+    "define *vector-valued* parameters:\n",
+    "\n",
+    "- `mu`: a length-`num_groups` vector of group means.  \n",
+    "- `sigma`: a length-`num_groups` vector of group standard deviations\n",
+    "  (or we could use a single shared `sigma` if we prefer).\n",
+    "\n",
+    "Then we use **indexing** with `data_labels` to pick the right parameter for\n",
+    "each observation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "5bc49764",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$\n",
+       "            \\begin{array}{rcl}\n",
+       "            \\text{mu} &\\sim & \\operatorname{Normal}(0,~10)\\\\\\text{sigma} &\\sim & \\operatorname{HalfNormal}(0,~2)\\\\\\text{y} &\\sim & \\operatorname{Normal}(f(\\text{mu}),~f(\\text{sigma}))\n",
+       "            \\end{array}\n",
+       "            $$"
+      ],
+      "text/plain": [
+       "   mu ~ Normal(0, 10)\n",
+       "sigma ~ HalfNormal(0, 2)\n",
+       "    y ~ Normal(f(mu), f(sigma))"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "with pm.Model() as model:\n",
+    "    # Vector of group means\n",
+    "    mu = pm.Normal(\"mu\", mu=0.0, sigma=10.0, shape=num_groups)\n",
+    "\n",
+    "    # Vector of group standard deviations (half-normal prior)\n",
+    "    sigma = pm.HalfNormal(\"sigma\", sigma=2.0, shape=num_groups)\n",
+    "\n",
+    "    # The likelihood: for each observation i,\n",
+    "    #   data[i] ~ Normal(mu[data_labels[i]], sigma[data_labels[i]])\n",
+    "    likelihood = pm.Normal(\n",
+    "        \"y\",\n",
+    "        mu=mu[data_labels],\n",
+    "        sigma=sigma[data_labels],\n",
+    "        observed=data,\n",
+    "    )\n",
+    "\n",
+    "model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a6f07da",
+   "metadata": {},
+   "source": [
+    "Notes:\n",
+    "\n",
+    "- `mu[data_labels]` creates a 1D array where each element is the mean\n",
+    "  corresponding to the group of that observation.  \n",
+    "- Similarly for `sigma[data_labels]`.  \n",
+    "- This is the crucial **vectorization trick** that avoids explicit Python loops.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7018a96c",
+   "metadata": {},
+   "source": [
+    "## 4. Sampling from the posterior\n",
+    "\n",
+    "Now we run MCMC to obtain samples from the posterior distribution of the\n",
+    "parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d54b6d95",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n",
+      "Sequential sampling (1 chains in 1 job)\n",
+      "NUTS: [mu, sigma]\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2fc77221f1204793a41b2527af50d1ed",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 1 chain for 300 tune and 300 draw iterations (300 + 300 draws total) took 409 seconds.\n",
+      "Only one chain was sampled, this makes it impossible to run some convergence checks\n"
+     ]
+    }
+   ],
+   "source": [
+    "with model:\n",
+    "    idata = pm.sample(\n",
+    "        draws=300,\n",
+    "        tune=300,\n",
+    "        chains=1,\n",
+    "        cores=1,\n",
+    "        target_accept=0.9,\n",
+    "        random_seed=RANDOM_SEED,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20d662df",
+   "metadata": {},
+   "source": [
+    "## 5. Inspecting the results\n",
+    "\n",
+    "We compare the posterior means of `mu` and `sigma` to the true values used to\n",
+    "simulate the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "a6cc57d9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "arviz - WARNING - Shape validation failed: input_shape: (1, 300), minimum_shape: (chains=2, draws=4)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Posterior summary for mu:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mean</th>\n",
+       "      <th>sd</th>\n",
+       "      <th>hdi_3%</th>\n",
+       "      <th>hdi_97%</th>\n",
+       "      <th>mcse_mean</th>\n",
+       "      <th>mcse_sd</th>\n",
+       "      <th>ess_bulk</th>\n",
+       "      <th>ess_tail</th>\n",
+       "      <th>r_hat</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>mu[0]</th>\n",
+       "      <td>-2.410</td>\n",
+       "      <td>0.063</td>\n",
+       "      <td>-2.548</td>\n",
+       "      <td>-2.310</td>\n",
+       "      <td>0.002</td>\n",
+       "      <td>0.004</td>\n",
+       "      <td>625.0</td>\n",
+       "      <td>218.0</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mu[1]</th>\n",
+       "      <td>-1.208</td>\n",
+       "      <td>0.079</td>\n",
+       "      <td>-1.355</td>\n",
+       "      <td>-1.055</td>\n",
+       "      <td>0.004</td>\n",
+       "      <td>0.005</td>\n",
+       "      <td>569.0</td>\n",
+       "      <td>99.0</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mu[2]</th>\n",
+       "      <td>0.620</td>\n",
+       "      <td>0.081</td>\n",
+       "      <td>0.475</td>\n",
+       "      <td>0.779</td>\n",
+       "      <td>0.004</td>\n",
+       "      <td>0.006</td>\n",
+       "      <td>515.0</td>\n",
+       "      <td>164.0</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mu[3]</th>\n",
+       "      <td>1.078</td>\n",
+       "      <td>0.082</td>\n",
+       "      <td>0.905</td>\n",
+       "      <td>1.203</td>\n",
+       "      <td>0.003</td>\n",
+       "      <td>0.005</td>\n",
+       "      <td>743.0</td>\n",
+       "      <td>191.0</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mu[4]</th>\n",
+       "      <td>2.551</td>\n",
+       "      <td>0.067</td>\n",
+       "      <td>2.425</td>\n",
+       "      <td>2.671</td>\n",
+       "      <td>0.003</td>\n",
+       "      <td>0.003</td>\n",
+       "      <td>503.0</td>\n",
+       "      <td>254.0</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        mean     sd  hdi_3%  hdi_97%  mcse_mean  mcse_sd  ess_bulk  ess_tail  \\\n",
+       "mu[0] -2.410  0.063  -2.548   -2.310      0.002    0.004     625.0     218.0   \n",
+       "mu[1] -1.208  0.079  -1.355   -1.055      0.004    0.005     569.0      99.0   \n",
+       "mu[2]  0.620  0.081   0.475    0.779      0.004    0.006     515.0     164.0   \n",
+       "mu[3]  1.078  0.082   0.905    1.203      0.003    0.005     743.0     191.0   \n",
+       "mu[4]  2.551  0.067   2.425    2.671      0.003    0.003     503.0     254.0   \n",
+       "\n",
+       "       r_hat  \n",
+       "mu[0]    NaN  \n",
+       "mu[1]    NaN  \n",
+       "mu[2]    NaN  \n",
+       "mu[3]    NaN  \n",
+       "mu[4]    NaN  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "arviz - WARNING - Shape validation failed: input_shape: (1, 300), minimum_shape: (chains=2, draws=4)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Posterior summary for sigma:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mean</th>\n",
+       "      <th>sd</th>\n",
+       "      <th>hdi_3%</th>\n",
+       "      <th>hdi_97%</th>\n",
+       "      <th>mcse_mean</th>\n",
+       "      <th>mcse_sd</th>\n",
+       "      <th>ess_bulk</th>\n",
+       "      <th>ess_tail</th>\n",
+       "      <th>r_hat</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>sigma[0]</th>\n",
+       "      <td>0.919</td>\n",
+       "      <td>0.045</td>\n",
+       "      <td>0.834</td>\n",
+       "      <td>0.999</td>\n",
+       "      <td>0.002</td>\n",
+       "      <td>0.003</td>\n",
+       "      <td>696.0</td>\n",
+       "      <td>201.0</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>sigma[1]</th>\n",
+       "      <td>1.087</td>\n",
+       "      <td>0.056</td>\n",
+       "      <td>0.993</td>\n",
+       "      <td>1.197</td>\n",
+       "      <td>0.002</td>\n",
+       "      <td>0.003</td>\n",
+       "      <td>743.0</td>\n",
+       "      <td>227.0</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>sigma[2]</th>\n",
+       "      <td>1.042</td>\n",
+       "      <td>0.050</td>\n",
+       "      <td>0.942</td>\n",
+       "      <td>1.134</td>\n",
+       "      <td>0.002</td>\n",
+       "      <td>0.004</td>\n",
+       "      <td>650.0</td>\n",
+       "      <td>208.0</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>sigma[3]</th>\n",
+       "      <td>1.042</td>\n",
+       "      <td>0.057</td>\n",
+       "      <td>0.928</td>\n",
+       "      <td>1.143</td>\n",
+       "      <td>0.002</td>\n",
+       "      <td>0.004</td>\n",
+       "      <td>664.0</td>\n",
+       "      <td>213.0</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>sigma[4]</th>\n",
+       "      <td>0.971</td>\n",
+       "      <td>0.054</td>\n",
+       "      <td>0.881</td>\n",
+       "      <td>1.072</td>\n",
+       "      <td>0.002</td>\n",
+       "      <td>0.003</td>\n",
+       "      <td>612.0</td>\n",
+       "      <td>188.0</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           mean     sd  hdi_3%  hdi_97%  mcse_mean  mcse_sd  ess_bulk  \\\n",
+       "sigma[0]  0.919  0.045   0.834    0.999      0.002    0.003     696.0   \n",
+       "sigma[1]  1.087  0.056   0.993    1.197      0.002    0.003     743.0   \n",
+       "sigma[2]  1.042  0.050   0.942    1.134      0.002    0.004     650.0   \n",
+       "sigma[3]  1.042  0.057   0.928    1.143      0.002    0.004     664.0   \n",
+       "sigma[4]  0.971  0.054   0.881    1.072      0.002    0.003     612.0   \n",
+       "\n",
+       "          ess_tail  r_hat  \n",
+       "sigma[0]     201.0    NaN  \n",
+       "sigma[1]     227.0    NaN  \n",
+       "sigma[2]     208.0    NaN  \n",
+       "sigma[3]     213.0    NaN  \n",
+       "sigma[4]     188.0    NaN  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "print(\"Posterior summary for mu:\")\n",
+    "display(az.summary(idata, var_names=[\"mu\"]))\n",
+    "\n",
+    "print(\"\\nPosterior summary for sigma:\")\n",
+    "display(az.summary(idata, var_names=[\"sigma\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81b57ed3",
+   "metadata": {},
+   "source": [
+    "### Optional: visual comparison\n",
+    "\n",
+    "If `matplotlib` is available, we can visualize the posterior mean of each\n",
+    "parameter against the true (simulated) value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "03e450bf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA94AAAGMCAYAAAAstHr+AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjcsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvTLEjVAAAAAlwSFlzAAAPYQAAD2EBqD+naQAAqldJREFUeJzs3QV4E+cfB/Bvkiq0tEChxaFYgeIuw50xGLYxwzcYsCEbgwk2YYJt+P4M2GAwhk/R4cNtyJDiUlq0BvX8n99bkiUV2kLb2PfzPGl6l8vlvfcuufvdaxq9Xq8HEREREREREWULbfasloiIiIiIiIgYeBMRERERERFlM5Z4ExEREREREWUjBt5ERERERERE2YiBNxEREREREVE2YuBNRERERERElI0YeBMRERERERFlIwbeRERERERERNmIgTcRERERERFRNmLgTURE2Wrbtm3QaDTqObN69+4NDw+PDC0rnzF+/PgnSCGlZ9GiRSp/L126xMxykO8eERFlLQbeRESPPPfcc8iVKxciIiLSzJOXX34ZLi4uuHPnTpbm22effYa1a9dyX9ATefDggbrpwAArfUuXLsX06dN5pBERUY5i4E1EZBJUP3z4EGvWrEkzuFm3bh3atm2L/PnzZ2m+2XPg3bhxY5Wv8kzZQ47NCRMmZFvg/eqrr6p9WKJECdg6Bt5ERGQJDLyJiExKvD09PdWFeWok6I6KilIBui2QtFpSdHQ0EhMTodVq4ebmpp7JthiOIZ1Op/ahVFvOqhsFtsBwDBMRET0tXgURET3i7u6OLl26YMuWLQgNDU2RLxKQS2AuAbq4f/8+hg0bhmLFisHV1RVlypTBF198keJCXaa//vprVK5cWQUvBQoUUKXmBw8eVK9LMCMBzvfff6/+l4e0bTY4cuQI2rVrhzx58qj2zi1atMDevXtTbYO7fft2vPnmmyhYsCCKFi2a6r4NCQmBk5OTKiFN7syZM2o9M2fOVNN3797FO++8o9Iuny1pkLQcO3Ys1bakP/30Ez788EMUKVJEVdsPDw9PtZ3pzp070b17dxQvXlzlneTh8OHDValqai5cuIA2bdogd+7cKFy4MCZOnAi9Xp/usXv9+nX07dsXvr6+6nMqVaqEBQsWpFhuxowZ6jVJc968eVGrVq0UN2BOnz6NK1eupPuZUuVbtleW79Gjh8ozqSHx9ttvq0DOVHx8PD7++GOULl1apa9kyZJ4//33ERMTY7acHCuy/T4+Puo4LVWqlNouIe2u5ZgSsk8Nx5Bpe3dJS7du3ZAvXz51DMr2/fLLLxk+htJq4z179myVb5J22S+DBw9W3wtTTZs2RWBgIA4dOqRqPUgeyzamZvLkyepzLl++nOK1MWPGqGYe9+7dU9Pnzp1D165d4efnp7ZJ0vriiy8iLCwszX0jafn999/V+g35JHme3jFs2KfJpZUvf/75J5555hl1vMpvRocOHXDy5Ek8juxjWZf8DiS3YcMG9dpvv/2mpiX9so/Kly+vjgc5vuT7lJE2+LK9pr8vpnkjD1NyHI4bN079thm+p6NGjUpxfG7atAmNGjWCt7e3+p2QdKW1j4mIHJWTpRNARGRNpDRbLnx//vlnDBkyxDhfAlC5+O3Zs6e60JUSuyZNmqjA7o033lAB5N9//62Cg+DgYLM2pP369VMX6BKw9u/fXwVbEnhK8CwB0OLFi9X8OnXq4PXXX1fvkUBMyMW6XMBL8CYXvM7Ozpg3b566QJYAqW7dumbpl4txCcLGjh2bZom3BKGSdtlGuag2tXz5clW6KRfxhoBXqsDLtAR7ErTL58v7T506pYItUxJESnAkwbpcnMv/qVmxYoXKw0GDBqmgYf/+/Sr4vXbtmnrNVEJCgrpRUa9ePXz55ZdYv369SrfkowTgaZG0ynskYJF9KfkiAZHsDwmm5KaJ+N///oe33npLBaaG4Piff/7Bvn378NJLLxnXV6FCBbXdGa3OLUG3BDmTJk1S+/qbb75RQeMPP/xgXEb2uxxv8tkjR45UnynL//vvv8YmD3ITqHXr1ir9o0ePVsGNBFirV69Wr8v8OXPmqLx8/vnn1c0jUaVKFeMx1LBhQxVIyvslGJR937lzZ6xatUq9J7PHkJBgVAL9li1bqs+WmzaSjgMHDmD37t3qWDWQPhHk+JfA+JVXXlHHYFp5Jse5pO/dd981e03mST7IjZHY2Fh1I0KOsaFDh6rgW76LEphK4O/l5ZXq+j/44AMVmMtxNm3aNDUveed9GT2G0yLf5169eqn0yY04Oc4lXyQwlZtohkA/Ofkt8Pf3V9sp70/+vZTtlnUKyWP5vZH8lBsOcjzIZ8jvgnwv5YbB05IbhnKTcdeuXep3SY7/48ePq3w7e/assWmMHF/PPvusOt7k+ygBelBQkDoGiIjIhJ6IiIzi4+P1hQoV0tevX98sV+bOnSvFq/oNGzao6Y8//lifO3du/dmzZ82WGz16tF6n0+mvXLmipv/66y/1vrfeeitFLicmJhr/l3X16tUrxTKdO3fWu7i46M+fP2+cd+PGDb2np6e+cePGxnkLFy5Un9OoUSO1DemZN2+eWv748eNm8ytWrKhv3ry5cTo6OlqfkJBgtszFixf1rq6u+okTJxrnbd26Va3P399f/+DBA7PlDa/Js0HyZcSkSZP0Go1Gf/nyZeM8yRN579ChQ83yrUOHDipfbt26ZZwvy40bN8443a9fP7Uvb9++bfY5L774ot7Ly8uYhk6dOukrVaqUbp7J+ps0aZLucpIGWfa5554zm//mm2+q+ceOHVPTR48eVdP9+/c3W+6dd95R8+XYEWvWrFHTBw4cSPMzJR+Sb79BixYt9JUrV1b70jQPGzRooC9btmyGjiHDa7LvRWhoqMr/1q1bmx0fM2fOVMstWLDAOE/yTObJdygj5LtXs2ZNs3n79+9X6/jhhx/U9JEjR9T0ihUr9Jklx06JEiVSzH/cMWzYp8klz5eIiAi9t7e3fsCAAWbL3bx5Ux1zyecnN2bMGL2zs7P+7t27xnkxMTFqnX379n3s92fPnj1meZTWd0+2PbXfGtlPpsf34sWL9VqtVr9z585Ufwt3796tpqdNm6amTb+LRESUEquaExGZkNJeKUXas2ePWbVNqXYspXRSzVtIqayUREsp1O3bt40PKf2TEtodO3ao5aREUUpck5csi/Tay8p6Nm7cqEompSTMoFChQqokVkqipOTW1IABA9Q2pEdKRaW6uZSkGZw4cUKVlr3wwgvGeVJ6ZWibLemRkktDVdLDhw+nWK+U1EmNgPSYLiOlqpJ3DRo0UNXHpVQwOdPaB4YSbCn13Lx5c6rrl/VI3nfs2FH9b7qPpNRQSj0N6ZcSZCkBlVLEx5H1ZKbzMql2bUpKZsUff/xh9jxixAiz5aTkW0iVaEP6hJTmxsXFITOkpsZff/2lSpKlt35DHsh+lHyQ6tpSUpzZY0jyXfJfag2Ytt2X90rtDEPaTY+jPn36ZCjNcvxJtfTz588b58lxKuvo1KmTmjaUaEstlKxuL57RYzg1UuVaStylZozpMSf5KbVTtm7dmu62yz421GYQ8hsg6zT9XpqmT5aX/SnVweVYSe17+STkN05KuQMCAsy2pXnz5up1w7YYjk/pA4Pt4YmI0sbAm4goGUPnaYY2vhKUSdVwCcgNAYkELFLlWarkmj4k8BaGNuISPEh1bGlbm1m3bt1SQYUEucnJBbFc5F69etVsvlQHzwhpKyw3EaRaq2lwI8G4oaqykM+QqqVly5ZVgY+8T7ZTqmKn1pY2o58vbaWlnankiwTysk6pxi2Sr1cCO9MbD6JcuXLqOa02rZJ3Eqx8++23KfaRIQA07KP33ntPpUGq+st2SsCcFdVkZV2mpPmAbIshzdJOV6YlYDIl1aYlmDG0c5Z8kbbMUq1b8l+Cz4ULF6ZoZ5saqfIrNww++uijFPlguBmUvD+DjOxDQ9qSH5tSLVv2VfI22lLNPaNVtqVZg+SL4aaQpF+CQEM/B4Y0yg2L+fPnqzyRmwizZs16bPvujMroMZwa+V0QEpwmz28JoFPrO8JU1apVVaBrekNM/pdtNAS8QvpCkKYAhv4lDN9LOeazIg8M2yLVyJNvh+G7Z9gWuSEgTRmk2YTcnJTfSfldYRBORGSObbyJiJKpWbOmuvhdtmyZ6iBInuXi37Q3c7mobNWqlWqPmhrDxWlOy0xJnVwgSxB69OhRVKtWTV0sSzAuF/Gmw5xJ0CYdeUnbVwmUJSiSks7ULqwz8vlSci55J6WxEvRKXku7Yyl5lWA8Ky7YDeuQ9sTJ28saGNpAy00MaZ8sJcpyM0VKyqXTMAlsUuuA7kmlVcMhvZoP8vrKlStVO/Fff/1VlfLK/pgyZYqal7yNcmr5IO2VDe2Dk0se+D9pae/jZGadcqNKapPI8SjfP9lGuVEj7aVNyfbL8SIlrRLUSjt9Q3v6tDoWfNK0prWP5FhOLb+lnbfcQElObmylRwLZTz/9VJUuS8ds0gmelKCbvldqT8jNF/ke1q9fX9UAkDTKdzq978/jtsW0poOsRzpVnDp1aqrLS9BvyC+p4SMl4FLTQb5DcrNAbhTIfslIDRwiIkfAwJuIKBUSZEvAKSW7UvItpZe1a9c2K72MjIw0lnCnRZaTQEmCzMeVeqd2MSylS9JJkgSFyUkv1RIAGy5+n4RUYZeO4Qyla9JhknQOZ0oCvmbNmuG7774zmy8la6YBemZIB03yWdKp2GuvvWZWTTc1EgBIJ2+mNzPk/SKtjqok7yRokWAivX0kJPCXgEceUoVaSv0l+JH8kB6zn7TE0LT0VEqfZVsMaZYxsWValpPg37RTOMnf5GNmS0dx8pB0yTEpx6j0wC0ljWkFU4aaAtLRWUbyIaMMaZNj07Q2guTdxYsXn/qzZD9IJ2+yfjk+5XsgzQaSk8BQHtILuXQ2JiWvc+fOxSeffJLmup9kSDRpUiJkvxiqVovkJfuGThGlR/gnzQPZdrnhIzeApARZmpNIQJ38eyk3lOTmg4F0Cpi8R/m0tiW15WRbTPelbIuMXiA349LLM/ktkuXkIYG63LCTjuwkGM/K446IyJaxqjkRUSoMpdtS6iklwsnH7pY2s9IOXILq5OSiVnrcFlJFWErLUys5NR0OSwK/5BfDUlIkvThLiZ5plWoJzCTwkl6SDVVvn4QEEFIKKiWLEsBJVWAJxpOnIfmwXVLtN3m74MwwlICZrlf+lyHX0mIY3sywrExLMGloc5/aZ0jeS/AibddTq4puIO1jTUk+VKxYUX2OaZvqjA4nZiBVn01Jr+1CqkyL9u3bq2fTHvCFoYRRhqAS0hN68n0gNRSEobq5oRfr5MeQBIDS07X0RC+97T8uHzJDginJJ+mp3TRtcoNGqjob0v6kZN/JPpTaJnK8Sa/Z8h0xkGDU8B0zkABcAsD0quDLejJbHdsQUBv6bhCGIQBNyfdJvpMSeKbWHj8j+S03YWRb5IaDPKRPBxmGLb3vpRxfyUvg09oWqRUgN0kMpLZH8mYr8hsn33Pp9T85qepu6PFebioml/z4JCIilngTEaVKSiqlsy8JekXywFuGOpIqoBIQSHVXqZ4uF6JSmiulURIoS4mwlBa/+uqrKkCRkk0ZFktKOaXNuLxm6DRM3i8dVknQJVVt5fOlMyYpuTOMkSslgFLdVIIouaCVobWelpSuSXVsqVotQYNpaZ6Q7ZMhgqRKuuSHbN+PP/6Yos11ZkjVcrn4l+rPcmEvgYoEyIbxmZOTEmepviolfJInMiSYVGmVasiG8atT8/nnn6sSN3mPdPolwbQECdL5lOS1IWCQmxtSLVhKS6WEUYbyksBegkcpNX/S4cSk5FeGY5J9LjdplixZojrFk3a8Qp5lm6QdugTMsm4ZVk2CObkBIseHkGnZPzLsl+SbdJImwZDkmyF4l+q+sn0SqEnNAKldIWNny0NuAMjxI8Gc5IPsO7l5I2mS/guSj8meEZLvUhtAbijJ9sl2Sum0pFNqhsgx9TTkhoFsv3wfZHtNOxYT0mGcfHekPbhsrwThUr3bcMPlceS7JvkkbcQlrVJVP7XSdFNyjMiQgTIUnXz35XNkPHjJB9ObMbJPZFgv+c7XqFFDlVQblpFjVo4x05tIaZHtlZt+cuzLZ5p2YGf4Xsr2ShVz2e+yL+WYlqH50iM1JOQ3SvabBNfSD4Ucm4abCwayDXJTbuDAgep7JGmXwF5uQMl8uekoQ6DJ74PckJDvi9SEkLbfchxIdX857oiI6JFUejonIiK9Xj9r1iw1TE6dOnVSzQ8ZOkiG/ylTpowaWsnHx0cN0TR58mR9bGyscTkZmumrr77SBwQEqOUKFCigb9eunf7QoUPGZU6fPq2GB3N3d1efaTrcz+HDh/Vt2rTRe3h46HPlyqVv1qyZ/u+//051WKPHDTmVmvDwcONnLlmyJMXrMgTVyJEj1bBcslzDhg3VsEXJhx4yDFuU2vBOqQ1pdOrUKX3Lli3VNkm+yTBLMsyWLCfbYiD5IEOtyXBqMnSVbL+vr68a3in5MGepDacVEhKiHzx4sL5YsWJqmCY/Pz81vNa3335rNrSa5H3+/PnVMGmlS5fWv/vuu/qwsLCnGk5MtrFbt25q6Le8efPqhwwZon/48KHZsnFxcfoJEyboS5UqpdIn6ZRjynToL9n/PXv21BcvXlylr2DBgvpnn31Wf/DgQbN1yTEhw3DJMZY8LyT/XnvtNbX98jlFihRR61i5cmWGjqHkw2aZDh8mx7WsU/bLoEGD9Pfu3TNbRvIsI8O1Jfe///1PfabkX/J8u3DhghpeS/aVm5ubPl++fOp7sXnz5nTXGxkZqX/ppZfUEF2yfsPQYo87hoV8X+vWravyV/bF1KlT08wXWZd8Z2UIMUmfpLN3794p9llazp07p9Yrj127dqV4XfK4T58+6rsj3yH5LPkNST5UWGrfPTFlyhR1DMjxJN9pSVfy77SQ37EvvvhC7T9ZVo5jOcbkmDV8P7Zs2aKG5CtcuLDKG3mW4zX5UItERI5OI38MQTgRERE9nfHjx6uSYKlW/KTt4ImIiMi+sI03ERERERERUTZi4E1ERERERESUjRh4ExEREREREWUjtvEmIiIiIiIiykYs8SYiIiIiIiLKRgy8iYiIiIiIiLIRA28iIiIiIiKibMTAm4iIiIiIiCgbMfAmIiIiIiIiykYMvImIiIiIiIiyEQNvIiIiIiIiomzEwJuIiIiIiIgoGzHwJiIiIiIiIspGDLyJiIiIiIiIshEDbyIiIiIiIqJsxMCbiIiIiIiIKBsx8CYiIiIiIiLKRgy8iYiIiIiIiLIRA28iIiIiIiKibMTAm4iIiIiIiCgbMfAmIiIiIiIiykYMvImIiIiIiIiyEQNvIiIiIiIiomzEwJuIiIiIiIgoGzHwJiIiIiIiIspGDLyJiIiIiGxAyZIl0bt37xz5LPkc+TxrTeulS5eg0WiwaNEim81jciwMvImewMWLFzFkyBCUK1cOuXLlUo+KFSti8ODB+Oeff5inRERklxz5/PfZZ59h7dq1lk4GZYG///4b48ePx/3795mflGOccu6jiOzDb7/9hhdeeAFOTk54+eWXUbVqVWi1Wpw+fRqrV6/GnDlz1IVJiRIlLJ1UIiKiLOPo5z8JvLt164bOnTtbOikEqOPs4cOHcHZ2fqLAe8KECapk29vb2+y1M2fOqOOaKKsx8CbKhPPnz+PFF19UP/ZbtmxBoUKFzF7/4osvMHv27HR/sKOiopA7d27mPRER2QSe/+xPdHQ0XFxcbDbIlGrmbm5uWb5eV1fXLF8nkbDNbxqRhXz55ZcqaF64cGGKoFtIKcBbb72FYsWKGefJ3VQPDw910dK+fXt4enqqkgIh6xo5cqRaXn7oy5cvj8mTJ0Ov12eoDZPMl6pSBvK/zJPShx49eiBPnjzInz8/3n77bXWCTU/Tpk0RGBioqgs2adJEVSEsU6YMVq5cqV7fvn076tatC3d3d5XWzZs3p1jH9evX0bdvX/j6+qptqlSpEhYsWGC2TGxsLMaOHYuaNWvCy8tL3YR45plnsHXrVrPlDNsuefLtt9+idOnSap21a9fGgQMHzJa9efMm+vTpg6JFi6plZP906tRJrYOIiJ6OvZ//zp07h65du8LPz08Fc3IukRvtYWFhxs+TNH///ffqf3kY2gFfvnwZb775ptoGOT/K53bv3j3F+Ue2Q963e/dujBgxAgUKFFDnv+effx63bt0yW1by4ZNPPlHpkHNxs2bNcPLkyRTpvnv3Lt555x1UrlxZ5bVsd7t27XDs2DGz5bZt26Y++6effsKHH36IIkWKqPWGh4er16UKvZz/Zdvlec2aNenmWWbTKqRq97Bhw4z7Xa4xpNAiMTFRvR4XF4d8+fKp83lyklZJn2xvWseHXL/IfvH391fLyv6Ua5I7d+6YHSvvvvuu+r9UqVLG/WnYX6m18b5w4YLap5I22cZ69erh999/TzWPf/75Z3z66acqPyQNLVq0QFBQUKaON7JPLPEmymQ1OzlJSPCZGfHx8WjTpg0aNWqkLizkR1tOVM8995wKNvv164dq1aphw4YN6mQgweu0adOeeN/IRYecOCZNmoS9e/fim2++wb179/DDDz+k+15Z7tlnn1UnADnJSNVB+f/HH39UJ8uBAwfipZdewldffaWq3F29elVdTImQkBB1MpITj7QBlIuKP//8U22fnDDl/UL+nz9/Pnr27IkBAwYgIiIC3333ncqj/fv3q7wwtXTpUrXMG2+8odYtF4BdunRRJ0JDFTM5gcmJfujQoWrbQ0NDsWnTJly5cuWpOochIiL7Pv/JzWBJY0xMjDqHSDAk6ZBtlkBRbhAvXrwY/fv3R506dfD666+r98nNYCE3gqXqspwrJYCSAE7OnXIz+9SpU2qbTcln5M2bF+PGjVPLTp8+XZ0zly9fblxGbk5LMCs3LORx+PBhtG7dWqXVlJwHJWiW87UEkXIenjdvnrp5Lp9duHBhs+U//vhjVcotwatsr/y/ceNGdQ6VtvqSbxKkGm5kZ0RG0/rgwQOVLslbOZ8XL15c5duYMWMQHBys8kHO6XIjQpouyHZI+gxkOyXNks9pkfO+5ImkX/ajXBfIjXt5luNBriHk+uHs2bNYtmyZOtZ8fHzUe+WaJTWSpw0aNFDpl5tLcmNFbsDIMSwFE5JeU59//rmqRSB5LIG0XLPIDad9+/Zl+HgjO6UnogwJCwuT2/D6zp07p3jt3r17+lu3bhkfDx48ML7Wq1cv9b7Ro0ebvWft2rVq/ieffGI2v1u3bnqNRqMPCgpS0xcvXlTLLVy4MMXnyvxx48YZp+V/mffcc8+ZLffmm2+q+ceOHXvsNjZp0kQtt3TpUuO806dPq3larVa/d+9e4/wNGzakSFe/fv30hQoV0t++fdtsvS+++KLey8vLmC/x8fH6mJiYFHno6+ur79u3r3GeYdvz58+vv3v3rnH+unXr1Pxff/3V+F6Z/uqrrx67fURElHn2fv47cuSIWmbFihWPzYfcuXOrbUrOdJsN9uzZo9b5ww8/GOfJdsi8li1b6hMTE43zhw8frtfpdPr79++r6dDQUL2Li4u+Q4cOZsu9//776v2maYiOjtYnJCSYfbbkm6urq37ixInGeVu3blXv9ff3T5HeatWqqXO34fPFxo0b1fIlSpR4bJ5kJq0ff/yxysOzZ8+arUOOD9n+K1eumF1fGM7xBu3bt1fpN93O5MdHavti2bJlarkdO3YY58n1gsyTdSQn22ya7mHDhqlld+7caZwXERGhL1WqlL5kyZLG/DfkcYUKFcyucb7++ms1//jx45k63sj+sKo5UQYZqmNJVa7k5K623Ck1PGbNmpVimUGDBplN//HHH9DpdOruqSmpeifXFFJS/KSkd1lTckfV8Jnpke0zvZssVeek45EKFSqYlXQY/pc7y0LSvGrVKnTs2FH9f/v2beND7uzKXV+5Cy5kuw13saV6mVSVk1KRWrVqGZcxJZ35SOmAgVRLN/1sqdon65NqXlKyQUREWcfez3+GEkYpdZdSzcySc5CBVJWWEmOpHSDnztTOaVJiLiWvpue0hIQEVWVdSDMuKRWVtJsuZ6g1ZkqqaxvaaMs65LNlP8m5O7XP7tWrl1l6paT56NGjar5pSWurVq1UCXh6MpPWFStWqG2V87npNULLli1V2nfs2KGWa968uSqFNq0BIOd2Kc2W64HHMd02aWIg65eaeCK1/MgIOXakpoPU2jCQPJb9KDUWpGaBKSltNy2pT37N8rTHG9kuBt5EGWSoTh0ZGZniNakOJSeEJUuWpPpeafuWvMqWnGClCphhvQYS4Bpef1Jly5Y1m5bqcHJizkh7Z0mn6cnTcJIwbbdnmCcMga60T5MqUlKly/QiTB6GtlpS/dtAqmlVqVJFtW2SaluynLSXSq19k1RHM2UIwg2fLRce0kZMLtakbXnjxo1V1S5p901ERE/H3s9/UkVb2lxLEygJ+ORmsdxAyGh7W+lZW6pbG9otyzrknCbnxCc5pxm2P/m2yDpNb0Ibbl5LdWlZ1vSzpa1zap8t22oqrc8SErynJzNplXbN69evT3GNIIG36TWCHDNS9X3dunWqOraQqudyUyO9wFtu5Eu7frkWkCBc1m/Y5idtPy3bmFpepHW8prd/n/Z4I9vFNt5EGSSBpnQoc+LEiRSvGUp/0zqxm96RzqzkQbCB3B1+2nWkRkohMjPf0BGOoWOUV155Rd05T40E2kIu0KTjEhmSRdr0FSxYUK1f2pZJJzyZ/WzD3XUpbZc2YHIX+aOPPlLr++uvv1C9evV0t5uIiBz3/DdlyhR1XpJgT9o8S2m8oZ14em2dpbRXOp2T81D9+vVVfsnnSu0xw7kxs+e0zAxxJuc76UBM2m9L51+S35KW1D7btEQ4p0l6pCR91KhRqb4uY8MbSN7JTR25oS7XCtJhWUBAgBrCLr02/tJuXK4tpO8AKZmWz23btm2q+ZEdMrJ/n+Z4I9vFwJsoEzp06KDuUEoHYFLt6GnIkGRSRUs6DTO96y89shpeN71TKnfOTT2uREDuKpve1ZbeNOWEk52djMldZdkOuSAy3L1Oi3RGIj2Oyh1s04si6WjmaUjJhlRVlIfkgZx05eSWVkkMERFljCOc/6RncHlIr98SvDVs2BBz585VHYc9LoiXc5rccJbzjWk15+TpzijD9su2yLnSQGqWJW9OJZ8tvYhLB6Wm5LMNnYZl9LOSk/GsszKtco6WWhPpXSMIqbkmN3ukurlU8Zab6B988MFj3yOfJ0O9yvjcUgPBILVty0yBhGxjanmR/HjNrPSON7I/rGpOlAlyl1Z6J5U7y9LL5dPcrZaePyVInTlzptl8qTImJwQZDkTI0CBy8jS0fTKQ8cLTkryN3YwZM9SzYZ3ZdYdXqoZJO+/USkVMh0ox3A02zS/p7XPPnj1P9NnSRir5cDFygpcLOkM1NSIienL2fP6TNuzSz4gpCYik5Nj0HCJDf6UWTMs5Lfn2y+dmpmTelASm0ru3rMN0vdLrd0Y+W9pSSy/ZGSHBrdykluZfplWdpflA8rbLT5tWKY2W87zUSktO8tV0H0jey8gpv/76q+pRXl5Lr5p5atcWaaVF9qXhczNyvMoNJ9NrFBlaTprWyQ2djLSFf5LjjewPS7yJMkHaMMnQVjIMlrT3keEhpNqT/MhfvHhRvSY/nBmpJiTVouUutdzBlSp6sh6pbiTVjqSKmGGYEiFDmMjwFPIsHZDJRYgMhZEWSYsMcyFVq+REISW+MgRYelW0npakUYaHkaqHMkyYnIykvZV0aCKlG/K/kOHKpLRbhuCQUhRJr9zlleVTa0OYHskLGSdTTuqyDmkfJmOQysXh44YdISKijLHn85+UpspwXjIkl1R3lqBIgj3DDWWDmjVrqnPZ1KlTVRt1KVmX852c02R5qWIu5yD5XFlO+i950hpkMhSVVD2WdUvgd+TIEVXtOnkptrw+ceJE1ZeKDHl1/PhxNfynaelzeuRz5FwsJctyY0XO1RJIV6pUKd1zcmbSKtW/f/nlF7WcVLOW/JQAVtIsJfdyLJi+RwJtSYfUhpPA1NCmOi1yo8bQx4u0B5exyuW4kmMiOflsIcegXCfIzQM5Lg0BuanRo0erocfk5o1UCZfq/HKjQtYrhQ2ZbUqR0eON7JClu1UnskUy1MmgQYP0ZcqU0bu5uend3d31AQEB+oEDB+qPHj1qtqwMSSHDZ6RGhqOQYUQKFy6sd3Z21pctW1YNcWE6JIdheAwZqkuG5PL09NT36NFDDeGR1nAqp06dUsOyyLJ58+bVDxkyRP/w4cN0t0uGE6tUqVKqQ2vIUCHJyWcNHjzYbF5ISIiaV6xYMbVNfn5++hYtWui//fZb4zKyfZ999plarwx5Ur16df1vv/2m8sp06BLDUCGpDRNmuu0yfJl8puwDyWvJp7p16+p//vnndLeZiIgc+/x34cIFNZRl6dKl1Tbly5dP36xZM/3mzZvNlpPhNRs3bqy22XSoLBlSrU+fPnofHx+9h4eHvk2bNmrZ5MNSGYYTO3DggNl6DcNQybOBDFE1YcIENcyXfF7Tpk31J06cSLFOGU5s5MiRxuUaNmyohjKT87k8kn9GWkNYrVq1Sg2DJefkihUr6levXp3inJyWjKbVsN/HjBmjjh8ZhkzyrEGDBvrJkyfrY2NjzZaVY0GuJVIbei6t4cSuXbumf/755/Xe3t7qmOnevbv+xo0bKY4Xw/BmRYoUUcOlmg4tllq6z58/r44rWa8cI3Xq1FHXLabSyuPk6czo8Ub2RyN/LB38E1HWGD9+vGrbJNW6M9K2i4iIyB7w/EdE1o5tvImIiIiIiIiyEQNvIiIiIiIiomzEwJuIiIiIiIgoG7GNNxEREREREVE2Yok3ERERERERkaOO452YmIgbN27A09MTGo3G0skhIiJ6KjKQSEREhBoDOLNjv9oDnteJiMhRz+tWHXhL0F2sWDFLJ4OIiChLXb16FUWLFnW4XOV5nYiIHPW8btWBt5R0GzYkT548lk4OERHRUwkPD1c3lA3nN0fD8zoRETnqed2qA29D9XIJuhl4ExGRvXDU5lM8rxMRkaOe1x2vgRkRERERERFRDmLgTURERERERJSNGHgTERERERERZSOrbuOdUQkJCYiLi7N0MoieirOzM3Q6HXORiIiILDLcX2xsLHOeKJuuz51sfdy0mzdv4v79+5ZOClGW8Pb2hp+fn8N2vEREREQ5TwLuixcvquCbiLLn+tymA29D0F2wYEHkypWLwQrZ9E2kBw8eIDQ0VE0XKlTI0kkiIiIiB7kGCQ4OVqV6MiySVsuWqETZcX3uZMvVyw1Bd/78+S2dHKKn5u7urp7lyy3HNaudE1nI1kmAVgc0GZXyte1fAokJQLMxlkgZkd2btuksdFoN3mpRNsVr32w5h4REPYa3KmeRtNmr+Ph4FVwULlxYFWQRUfZcn9vsLS1Dm27+QJA9MRzP7LOAyIIk6N76aVKQbUqmZb68TkTZQoLuqZvOqiDblEzLfHmdsr4wS7i4uDBribLx+txmS7wN2BaW7AmPZyIrYCjpliDbMG0Iupt9kHpJOBFlCUNJtwTZF25H4rPnK2P+zotqekSrcqmWhFPW4DUIUfZ+N2w+8CYiIspyTUYhUa+HduunSNj+JXSJcUhs+j60DLqJsp0E13+fv421R25g3ZEb0AMMuonI5tlsVXMiIqJsEXEThzb+iIZ7aiFG76SCbnmW6fUngpnpRDnQoVFIeEzS/1LaBGBo8zLMdyKyaQy8pW1Loh57zt/BuqPX1bNMExGRAzq7AbEz6iFw99sYGDUHrpp4FXTLc/fIpRi05DCDb6Ls/hqGROLi7Sj1vwTdclU2468g5jvZnKZNm2LYsGGWTgZZCYevai6lFxN+PYXgsGhjphTycsO4jhXRNrBQjrcRGDduHMaPH5/ln0tERI8RFw1sHgfsmwvpXihU74VeTpswJa4bZiR0wVDdaox0XqkWnfCrG1pV9GMnT0TZZPwvJ9Szv09ubBnZRAXd0sZbNCtfEBUL5+H3z8HZyvX06tWr4ezsbOlkkJVwcvSgW0ovkpdv3wyLVvPnvFIjy4NvGSfRYPny5Rg7dizOnDljnOfh4WFW1Up6mnRycujdRESUvW6dAVb2A0KOq8lDCWVRU3fOGHQLw7ME3/pIYP/FaqhfmkNZEmU16b18z4W76v9BTUurAMu0w7Wvt5xD47I++LpndeRxY0DjqGzlejpfvnw5/plkvbR2N8h5bHyGHhHRcRj3y8kUQbdaz6Pn8b+cUstlZH3y2Rnh5+dnfHh5eakTimH69OnT8PT0xJ9//omaNWvC1dUVu3btQu/evdG5c2ez9Ui1Fam+YpCYmIhJkyahVKlSary5qlWrYuXKpNKZtJQsWRKffPIJXnvtNfUDVaJECfzyyy+4desWOnXqpOZVqVIFBw8eNL5H7h5Wq1bNbD3Tp09X6yIisjmHFwPzmiQF3bl8sKfeHOzUVzYLug1kWubrNIkIjfivlhQRZZ24hERUL+aNYvnc0aqir3G+BN/PVS0sF3vYeuYWusz+G5fvJFVHp+yR0WvqrHpkhjVdT8+ePRtly5aFm5sbfH190a1btzSrmssNgw4dOqh1y2csXbpUXUPLtbSBbMu8efPw7LPPqmGsKlSogD179iAoKEitL3fu3GjQoAHOnz9vfI/8L9fu8vly/V67dm1s3rw5U3lK2c+uilIfxiWg4tgNWbIuCaNvhkej8viNGVr+1MQ2yOWSNdk5evRoTJ48Gf7+/sibN2+G3iM/EkuWLMHcuXPVl3/Hjh145ZVXUKBAATRp0iTN902bNg2fffYZPvroI/X/q6++qr7Mffv2xVdffYX33ntPBeYnT57kMBNEZH8ibgLxDwH/ZsDzcxEalIDp8V5pLm4Ixpd5uuVgIokcx8jW5dVDCjSSVyf+pmd19H+mFAb8cBBBoZHoNGs35rxck7VPsklWXVNn1KXPO2Tp+nLieloKp9566y0sXrxYXT/fvXsXO3fuTHP9ck19+/ZtbNu2TVVBHzFiBEJDQ1Ms9/HHH2Pq1KnqIdfiL730ktqOMWPGoHjx4uo6fciQIermgoiMjET79u3x6aefqhsNP/zwAzp27KhqAcjyZB3sKvC2FxMnTkSrVq0yvHxMTIwKnuXOVv369dU8+XLK3T25Y/a4wFu+pG+88Yb6X6rpzJkzR90l6969u5onX3ZZZ0hIiLqLSERk8+JjASdpyQ3gmRFA3hJIrNQVS/ZfxaQ//n3sWyUM8PNyQ51SrD5IZIk2vFWKeuOXIY3w+g8HcexaGF79bh8mdgrES3UZXFDOX09fuXJFlUBL6bSUskvt0erVq6e6fimJl3UfOHAAtWrVUvPmz5+vAvzk+vTpgx49ephdi0shWZs2bdS8t99+Wy1jICXz8jAN3NesWaNqskqATtbBrgJvd2edKnnOiP0X76L3wgPpLreoT+0MXWDJZ2cVw5cxo6TqyYMHD1L8uMTGxqb55TeQquQGUj1FVK5cOcU8uRvHwJuIbFpCPLDjK+D070D/TYCzO6DV4WrRZzHquwPYc+GOWqxsQQ+cC4009qZsYAgDpPNNnfbxHfsQUebdiojBudAI1CmZD066tFtD+uZxw/I36uPdlf/g12M38P6a4/DN44oWFf6rmk5PL6PX1NYqJ66nZVkJtiVAb9u2rXo8//zzqop4clL6LO3Ma9SoYZxXpkyZVEvjM3J9Hh0djfDwcOTJk0eVeEtz0N9//11VZ4+Pj8fDhw/VjQGyHk72dnc0o9W9nylbQPVeLh2p6R9TqiHL5fQFltw5M6XValO0IY+LizP+L182IV+2IkWKmC0n1U0ex7SnRcPd5dTmSZuXjKSFiMgq3b8CrBoAXN2bNH1qHfRVXsCP+66oUu6o2AR1A3V0uwC8Wq8ENp66mWLEC79sHPGCiKCC6Im/nULzgIJY0Lv2Y7PEzVmHb16shvK+HjhxPVz1dk5ZK6uaUFpKTlxPSyn34cOHVdXxjRs3qtqjEgBLqba3t/cTpz2z1+fvvPMONm3apKrWSzAvbcilrbncNCDrYdvfqKcgwbRcQEnv5dZeqiHtSk6cSBpaw+Do0aPGL2DFihXVD4Lc1XpctfKsSsvNmzfN2l5JWoiIrNbJNcAvbwMxYYCLJ/DsNFwr1gGjv9uPXUG31SJSwvZV9yookT/pQk2CaxkyTGpHSUdqBT2TqpdbwzmByF6tP3lTPTcs45Oh5eU6ZEjzskhM1EP76LsZHZeAkPBo43eZKLuvp6UUu2XLluohw5hJwP3XX3+hSxfzDjrLly+vSqKPHDmiOn0zlLLfu3fvqXfS7t27VedxUtpuuIlw6dKlp14vZS2HDbwNF1YyZJi1l2o0b95cdXQmHSVIGw/p9EF+OAzVXuRum9zpGj58uLrz1ahRI4SFhakvoVQ/6dWrV5alRXpTlF7Pv/zyS3Unbf369apjB/kcIiKrEhsFrB8NHP4habpILei7zsdPQTp8On0nImPi4easxag2AejdoKTxwt1AgmwOGUaUc9XMD1xKGkasTaXMVRk3fHelUGD0qn/w1+lQzH65JhqVzVgAT44hO66nf/vtN1y4cAGNGzdWVcb/+OMP9V4JspMLCAhQwfnrr7+u+lSSgH/kyJGqdDq9ccnTI+3EZcxw6VBN1iXtwQ2l4WQ9HDrwtpVSDelIQb5Ao0aNUu05pCdD6RXx+PGkMWcNnSjInTzpjVF+AORum7Qhef/997M0LTKkgQybIJ1PyGd27dpV/Uh9++23Wfo5RERP7Y9RwNElSfWYGg3HjerD8d6af7HzXFIpd60SefFV96oo5cOSMSJL23QqREYKQ5WiXiiaN2X72IyQJiOX7z5AeHQ8ei3crwpRXqvP4U4p+66n5XUJeKV6uaxTAuBly5ahUqVKqS4vQX+/fv1UoC59J8nnyMhBMhTZ05Dez2V7pGd1Hx8f1SGbtP8m66LRZ3QAaguQA0bG5pO7TclLVOXgvnjxohoD72kPViJrweOaKAvdvwos7QF920n4+Y4/PvntX0TExMPVSYt325RHn4alcvwm6+POa47A0bef0ia9k8tNMfluDm5W5omzSqqav7/6OFYfua6mX6lXHOM6VoLzYzprc3S89rCca9euoVixYqq38xYtWlgwJfSk35HMnNf4K0RERPYh6vZ/1cqFdzEEv7QZvbflwnurjqugu3pxb/zx9jPo/4y/VdVsyiwZW1aqFBYuXFhVK1y7dm2675HOf6TkRtowSuc7ixYtMnu9ZMmSal3JH4MHDzZrbpT89YEDB2bLNpLjCHsQhz3nk0YVaBf4dEOXSqdrU3pUVR0lSu3dJXuv4LXv9uNeFDuZIsuTtt8yxJcEcX///TdefPFF9dsrJeBk/xh4ExGR7Tv/FzCnAfDLUODsBtXWc8XBq2g9fRe2n70FFyct3m8fgJUDG6B0AQ/YuqioKDVm66xZszK0vFzkdejQAc2aNVOdCQ0bNgz9+/fHhg0bjMtIL7wyDI3hIT3kiu7du5uta8CAAWbLSZ8fRE9j+7lbiE/Uo7yvJ/yz4Pupbgg1KY1vX62F3C46NVRg70UHUvRoTZTTpBd1qbYuVdGlIzSp1i43RU17LCf75fBtvImIyIbFxwJbPwF2f500XSAAt7U+GPX9QdXBkqhazBtTuldBmYKesBft2rVTj4yaO3euqiI3ZcoUY38du3btwrRp01S7RyEXgKY+//xzlC5dOkXvvjI+rbRNJMoqHasUQsn8uRD+MD5LM7VVRV+serOBGsFmdFspAbfdWi5kH+T31vCbS46HJd5ERGSb7pwHFrQ2Bt36mn2xttYSNF9yWwXdLjot3msbgFUD69tV0P0k9uzZo3rTNSUXfzI/NTL2q/T4K531JA9WfvzxR9V5T2BgIMaMGYMHDx6k+bkxMTGq/Zvpgyg5OcaqFPXOll7IA/zyYOPwxmYjFFy9+4Cl30SU41jiTUREtufEKuCXt4DYSMDNG/dbTcM7J4ph8+6z6mXpGXly96oo5+vYAbfBzZs34etrPkSTTEsg/PDhQzWcjSlpM37//n01Lqypl156CSVKlFBty//55x/Vc+6ZM2dUr76pkR57J0yYkA1bRJRxph2rBYVG4PlZf6NDlUKY2ClQNUMhIsoJDLyJiMgGaVTQrS/RABvLf4xRv91F2MNQOOs0GNayHN5o7A8n9mL8xL777jtVlV0CbFMy/qxB5cqVUahQIdUT7/nz51W19OSkRHzEiBHGaQn0pQdfIoMP1hxHTHwiXm/snyM3yo5cuY+o2Hj8dOAqLtyOwtxXaiJfbhfuECLKdgy8iYjINsQ+AFweje8b2AX343UYdcwPG38JUbMqF0kq5S7vx1Lu5KRNdkhIUj4ZyLQMfZK8tPvy5ctqaJu0SrFN1a1bVz0HBQWlGnhLD+ryIEpr6K81R67jQWwCXqlXIkcyqXutYvDxdMVbS49g/8W7eG7mLnzXqzZ/N4go27F+DRERWbfEBGDnFGBGTSAyVLXNXHf0Opr+4o6N/95WpdwjW5XD6jcb8OI5DfXr18eWLVvM5kmv5TI/uYULF6JgwYKqF/T0SA/pQkq+iTJLxu2WoLuQlxuqFPHKsQxsVr4g1gxugBL5c+HavYfoMns3tvxrfmOKiCirMfAmIiLrFR4MLO4MbJkIRNxA1P7Fqofit386ivsP4lCxUB78MqQRhrYoa9aO095FRkaqoNcQ+MpwYfL/lStXjFW8X3vtNePyMtb2hQsXMGrUKJw+fRqzZ8/Gzz//jOHDh5utNzExUQXevXr1gpOTeaU4qU7+8ccf49ChQ7h06ZIai1Y+Q8afrVKlSo5sN9mX9Sduquc2lfyg1eZsj+PS4eLaNxuivn9+RMUmoP8PB9XQg0RE2cVxrlLoiYwfPx7VqlVj7hFRzjvzZ9LY3Bd3AM65cLTGp3hmV2WsP3kTTloNhrcsh3VDGqJCoTwOt3cOHjyI6tWrq4eQdtTy/9ixY9W0jK9tCMKFDCX2+++/q1JuGf9bhhWbP39+imFtpIq5vE96M0/OxcVFvd66dWsEBARg5MiR6Nq1K3799dds316yP3EJidj8qJS5baBlhqfLm9sFP/Srg5frFkedkvlUEE6UHXg9nT65oSsjHBhuKNsjjV7q7GUT6c1U2ojJ3XVpQ9agQQN88cUXKF++fIbeL52weHl5ISwsTLVDMxUdHa3u8MvFhJub25MlcOskQKsDmoxK+dr2L5OqNzYbg6wmvcR+//336n9nZ2cUL15clRq8//77KUoYMmvbtm1o1qwZ7t27B29v7ywpVZHhYPLn58koJ2TJcU1k6+KigU0fAfu/VZPxBSvjU/d3sPCMs5oO8PPElB5VUalwzlVNzSqPO685AkfffvrPjrO38NqC/fDxcMG+91tCl8Ml3qbkUlg6eHNz1qnp+IREhEfHO0yna0977TFt01m1/95qUTbFa99sOYeERD2GtyqHrMbrafuSkJCAW7duqeEqnzYeysnvSGbOa9la4r19+3YMHjwYe/fuVXfZ4+Li1J3yqKgoWAUJurd+mhRkm5JpmS+vZ5O2bduqEolz586pUgO5E/bVV1/BWshJKD4+Hh4eHk8ddMt+JyLKMGnP/Sjovli2Nxrdfl8F3YYLO6labotBNxH9R2quiFYV/SwadAspZTME3eLTP/5Fxxm7cOoGx53PCNl/UzedVUG2KZmW+dm5f3k9bT90Op3qCNTagu6slK2B9/r169XdqEqVKqmqbYsWLVJV2KR9WLaKjUr7ISUpBlLS3fjdpCD7r0+SXpdnmZb5DYZmbL1PQHp5lYNLxkMdNGgQWrZsqdrLCSmtlhLwvHnzIleuXGpIFwnQTXuc7dixo3o9d+7cKn//+OMPVUVDSruFvCYnEsMYrNJuT2ogyJ0aqX0g+2PlypVmJeWy/J9//omaNWuq9O3atStF1RhZz8SJE1G0aFG1jLwm+zl5NZHly5ejSZMm6q7Qjz/+mGoeyHLz5s3Ds88+q7azQoUK2LNnj+odt2nTpmrbpJaEtCs0tW7dOtSoUUOt29/fX40RKzcJDKZOnaqGuZH3y7A1b775piq5N5DjUGoDbNiwQX2m3Fww/HCnxZA/8h6pzil52Lx5c4SGhqo8k/XIXS4Z4/bBgwfG95UsWRLTp083W5fkmeQrEaWh4duIK1oPs4p8gWbHW+PmA70q5V43uCFGtCrHcXeJ7IC/T26UKehhsWrmaYmIjsP2M7dw/f5DdJ3zt7EduiN6EBuf5kN6pDeQG6JDm5dRQfaUjWfU6/Is0zJfhorLyHqfBK+nbet6+t69e3j55ZdRoEABdS1dtmxZ1a9IWlXNJTaSZSSNEuNIjWFZ5v79+2Zp+O2331SNatn+bt26qWtxWVauwyUmeuutt1SJusHixYtRq1YteHp6qnhMrt/lmj675egtBSmCF/ny5Uv1danSLA/Tovsn8pn5uKNmyrYGXl7x3/SeWUnPO75KehjI/5f3AH1+/2/e9MrAgzsp1zk+abuehhx8d+4krVuCZQm05WCTYO69995D+/btcerUKVU1XWoRxMbGYseOHerLIPPlYJcvxapVq1SbuzNnzpgNEyNB95IlSzB37lx1AMt7X3nlFXXgS4BsMHr0aEyePFl9AeVAlYDT1Ndff63aBsoXXALQBQsW4LnnnsPJkyfVek3XI8vJMo+rtiQd9cgXWx6ynXLgy2dLx0BSBV/aGQ4ZMkQFt2Lnzp3qpsQ333yDZ555Rv2IGMaVHTdunHrWarXqdbnJIJ0JyQ+FdCgknQkZyBdStlO+eLK85MU777yT5k0CAwmYZ86cqb7YPXr0UA/50V+6dKn6MXr++ecxY8YMtS1ElEEP7gKHFgENh8kXGOvPReLD4JG4HRWnSkoGNSmNoS3KwNUp+2ohEVHO6v+Mv3pkY4vHJ+Lp5ow1bzbEkGWHVa/rA5ccwrttyuPNpqXVBb8jqTh2Q5qvNStfAAv71DFOz995UT3P+CtIPQzkfxm2bfkb/42g0OiLrbgbFZtinZc+T38khfTwetq6r6c/+ugjFbdIOqRKudwcePjwYarLStVuCaLffvtt9O/fH0eOHFHrTk7SIOn86aefEBERgS5duqjrcQnIpWBS0i6xUcOGDfHCCy8Ya+NKDCLBugTc0k+KxF+yfLbS55CEhAR9hw4d9A0bNkxzmXHjxsmvb4pHWFhYimUfPnyoP3XqlHpOuaI8aT+WdDNf9hO/tJdd0N582S9Kpb5cJvXq1UvfqVMn9X9iYqJ+06ZNeldXV/0777yjP3v2rNrm3bt3G5e/ffu23t3dXf/zzz+r6cqVK+vHjx+f6rq3bt2q3n/v3j3jvOjoaH2uXLn0f//9t9my/fr10/fs2dPsfWvXrjXPynHj9FWrVjVOFy5cWP/pp5+aLVO7dm39m2++qf6/ePGiWs/06dPTzQdZ7sMPPzRO79mzR8377rvvjPOWLVumd3NzM063aNFC/9lnn5mtZ/HixfpChQql+TkrVqzQ58+f3zi9cOFC9TlBQUHGebNmzdL7+vqmuQ5D/mzevNk4b9KkSWre+fPnjfPeeOMNfZs2bYzTJUqU0E+bNs1sXZKfkq+peexxTWSPLu7S66dUUL+lUdu+1g9delhf4r3f1KPllG36Y1f/+y2zB3I+S+u85ggcffvJdsTFJ+jHrTth/D2S36aHsfF6e5TWtYdh21N79F6wz2zZgA//THPZHnPNrz+rT9yY6nKZxetp27ue7tixo75Pnz6pvmaIIY4cOaKm33vvPX1gYKDZMh988IFZnJNaGuRaXOKeiIgI4zy5Npf5aTlw4IBaj+l7Mnp9npnzWo6VeEsp7YkTJ1T15bTIXRm542Ba4i2luJn2/o20X9MkKzF5NwjYNS2phFvnAiTEJlUzbzQc0CSriT/sOLKKVImQUmq54yLVt+XOlJSmyjir0rahbt26xmWljbXckfn333/VtFSXkOrpGzduVFXU5S7O44ZykbtJcjeoVatWZvOl1NzQI66BVLtIi+yPGzduqDtGpmT62LFjGV6PKdN0+/r6qmep1mI6Tzo0kM+WEnz5nN27d+PTTz81LiNVR2QZ2UYpiZZed6WEXzr1k/dJtRnT14U8ly5d2rgOGYM2I1VMkqdX1iN3FE3n7d+/P0PbTuTQEuKB7V8AOycD+kREeZTEGztcsSvqBqQ54MAmpfF2y7Is5SayMxInbD0TigalfczaVVsbJ50W45+rhLK+Hhi37iR+OXYDtyJisHRAXYcp+T410XzUA1PaZHlw6KOWmLPtvCrhdtZpEJegV9XMBzUtnWLZXe8lNYvMCryetq3r6UGDBqm45fDhw6rfr86dO6tq8KmR2ru1a9c2m1enzn+1LAySp0G2VaqYS5xlOs80XdLsWeIuyQep/i6xmJAm0RUrVkR2yZHAW6o2yBdDqjdL2+C0SJVdeTw1l9wZX1aqmkvQ3eyDpDbfho7VJAhP3tt5ZtabDmmnMGfOHDU8S+HChTPVkYBUt5AhYGRoGAm+5Ush1bqHDk3WJv0RQ3sMWb5IkSJmryXPb6m6nhUyuh6pOm9gOJGlNs/whZBtkTYoUo0kOanSLu1DpI2LfLHlx0SaNcjNnn79+qkbDYYfCtPPMHxORqq7JU9bausxpFVItZvk62Vnc+Tw7l0GVg8Aru5TWbHPqx36hHTHA7ihdIHcmNKjGqoVe/pRGYjI+vxzLQx9Fx2Ej4cr9r3fwuIdq6Xn5bolUMonNwb/eBi9GpR0mKBb5HLJ+LWpVDWXoFv64ZA234aO1Zx12hS9nWdmvenh9bRtXU+3a9dO9VUlVbql4+0WLVqowlmprv6kUkvD467PpZNviaPkIVXipdmtBNwyLduWnbI18JaMl2BwzZo1qq2wtBGwKoYg2xB0C8OzzDedzmISmJYpUybFfOmcQO4o7du3z3gHSNp+y10f0zswUhNg4MCB6iE1Bf73v/+pvJZAXph2ICDvkwBbDirT9tyZJXfI5CaB3CEzXY9Mp3YHKjtIJxCSF6nlneEOlnyx5EaEBL3i559/hqXIl9m0kwm5YyhtVogc1tkNwKoBQEwY4p09MC5xAH4Mqa1Kud9o7K/G5rbmUjAiejp/PuqsrG6pfFYfdBtI6fyOUc1U+2+DsIdx8HI3v7h3VIYg2xB0C8OzzDedzmq8nra96+kCBQqgV69e6iHty999991UA2+p7Zu8zfWBAwee+vOlBF9iq88//9xYs/rgwYPICdkaeMsdDOl0SnrNk17jbt5M+rGVsc4MnX5ZlBqn2yToNjBMy+s5TDoo69SpEwYMGKA6MJN8k47KpKRa5othw4apO0blypVT1SO2bt2qAnYhvaTLXR2pYSAdskk+yzqkM4Lhw4erL1GjRo1UR3cSMEswLQd+RsmXQzpdkCod0ju39EQovQ+m1ylZVhk7dqy6AycdRUiHC/JjINVEpBnDJ598on5ApERZOjiTnt9lG6VDOUuRns+lx0VJi3TyIOmX4RKIHFZuH+jjonDZvRJeuT8A1/QF4V8gNyZ3r4oaxfNaOnVElM0FMutPJN2MtrbezNNjGnRLj+edZu7GK/WK463mZaG1kRsI2UXG6TYNug0M0/J6TuP1tHVeT48dO1aNniQjMkmH2hKvGGKY5N544w1j58tS0i7xhlxTi6epeSLbLAWVsm1SgCnbLB2t2fxwYlKVWgI86cpe6vwbHjLUlFVoNibtEm2ZL69bgASzclDKF6J+/frqRCV3fAzVJqQ0W25qyIEq3fZLAG7oYVACdKk6IsG6tGeQav5CDijpSVCqpRveJ1XPM1sLQdqXSzt8GXtc2o7IUGKGrv5zglQDkS+pVLGXdh/16tXDtGnT1A0HIcOkyZf0iy++QGBgoLohINtsKVIbQWoHyL7s0KGDasti2g6FyCE8TBr2Q2yNKIaB2nFoee89XEdBNczMH289w6CbyAGcCYnApTsP1JCAzQIKwlZtOHETtyNjMH3zOQxddgQPY3O+oMaaDE8l6DaQ+fK6JfB62vqup11cXNS1sbRJb9y4sSqMkt7IUyMxigx9vHr1arW8xJUffPCBeu1pmiZLibsE8CtWrFC1gqXk+2mqumeGRnpYg5WSarlSOi7Bu5TMmpLG/VJlV3bK44arIrIlPK7Jrkh7qn1zgG2fI/KlXzBhvxYrDl1TL0mbycndq6BmidSHl7RXjzuvOQJH335HN23TWXy95RxaViiI+b3MO02yNT8fuIoP1h5XnYgFFsmD/71WC4W8rKA25xPgtQfZik8//VSVvF+9etVqviOZOa/l6DjeRETkICJDgbWDgKDNavKXH6ZgRVRPSO2wvg1L4Z3W5eHuwmYXRI5kw8mkJodtAwvB1vWoXQwlfXKrcb5PXA/HczN349tXa6I6m8wQZZnZs2erEnkZ4Umqu3/11VfG2ry2iIE3ERFlLQm21wwCokIRp3HBhNiXsSS6JUrmz4WvuldF7ZKOVcpNRMDVuw9w+mYEnLQaVeJtD+qUyod1gxui//cHVTX6F77dix/61kE9//yWThqRXTh37pxqc3737l3VNluaukpVdVvFwJuIiLJGfCywZQKwZ6aaPK8pjkHRg3FWXwx9GpbEqDYBLOUmclDF8uXCXyOb4Pj1MHjnShqBxV62a9WbDTDspyMIDotGlaJelk4Skd2YNm2aetgLBt5ERJQ1ji0zBt0/xLfCp/EvwzefN37qVoUlQEQE/wIe6mFvPFydMO/VWgh/GGcco1q6UIqJT+TwiERkP4G3YTB0InvA45ls2W7PtojWNsBP0fWwKbEWetUvgffaBRgvRImI7JWMSZ43938l+bO2BuH34zcxv1ctFPG2jU7XrLi/ZSK7uD632ash6Y5expy7ceOG6hZepp9mTDciS5/sYmNjcevWLXVcy/FMZPWiw4CdUxFV/x1M2nwJS/ZeATAERfO6Y2m3KmhQ2sfSKSQiK7B03xXsPHcLL9ctgUZl7f93ITw6Dt/vuYxbETHoNHMX5r1a06pHcJDhauUaWq5B5Jqa19NE2XN9brOBt2y8dOkeHBysgm8ie5ArVy7VeYQc30RW7eoBYFU/4P5lbNh7GkuiXlOzX6lXHGPaVUBuV5s9vRBRFlt75Dr2X7qLWiXzOUTgncfNGWsHN8SA7w/iVHA4en67D5O6VEbXmkVhjWQs5aJFi+LatWu4dOmSpZNDZLfX5zZ9ZSR3HSQT4uPjkZCQYOnkED31ic/JyYl3msm6JSYAu6ZBv/UzaPQJuJpYAEti6qmqlF92q4KGZez/opqIMk5KfQ9cvqv+bxvo5zBZJ7+JKwfVx/DlR7HhZAhGrjiGs6ERqpNJqZZubTw8PFC2bFnExcVZOilEdnt9btOBt5BMkCoy8iAiomwUfgNY/TpwaSfk9LMuoQE+jOuLZ+sE4Pv2AfB04+8wEZnbeOompOlw1aJeNtPWOatI/xZzXq6J6ZvP4pu/gjBv+wVcvv0Ac16pYZU32SXAkAcRZQ+bD7yJiCgHXNoN/fKXoXl4D1F6V4yN64M9Hq0w69WqaFyuAHcBEaVq/Ymb6rmNA5V2m9JqNRjRujzK+Hri3RXH0CyAbaiJHBUDbyIiStexKC+UehiHy4kl8VbcUNStVQfrO1RQbRmJiFIT9iAOe87fUf+3reSYgbfBc1ULo1aJvChsUuofG58IFyf26ULkKBh4ExFR6iJC8NDVB5M3nsGC3ZcRgA8Q6emPT16piSYs5SaidGz6NwTxiXqU9/W0y/G7M8s06L4bFYtuc//GG4398ULt4hZNFxHlDAbeRERkThpkHpiPxA0f4GPnd7D0fiU1u3Kthvjw2Yos5SaiDPFwdUK1Yt5oWp7NUZJbtv8KLtyKwnurjuPMzUi83z4ATjqWfhPZMwbeRET0nwd3kbB2MHRn/4BcAtaK3Y4teWrg8y5V0CygIHOKiDJMejGXh4yFS+bebFoaCYl6TN10Fgt2X8T5W5GY8VJ13tgksmO8tUZEREku7kTszPoq6I7V6zAx7lX8HfgJNg5rwqCbiJ6YNfbgbQ158laLspj9cg24OWux/ewtPD9rNy7djrJ00ogomzDwJiJydAlxiN80EfrvO8LlwU2cTyyEvs6fo+ErH2HyC9XhlYsdqBFR5uy7cAdhDzkmdHraVy6ElQMbwC+PG87fikKnWbtx9Op9Hm5EdoiBNxGRgws6sB5Ou6dAAz1+im+KbyssxMwRvdGigq+lk0Zp2LFjBzp27IjChQurkrO1a9emm1fbtm1DjRo14OrqijJlymDRokVmr48fP16ty/QREBBgtkx0dDQGDx6M/Pnzw8PDA127dkVISAj3E5kfJ3EJ6LPoAGp+vElVoabHCyzihV+GNETVYt7wzuWMkvlzMcuI7BADbyIiBxUTn4Av1p9G63VazIvvgNHaEcjXcx6+6Fkf3rlcLJ08eoyoqChUrVoVs2bNylA+Xbx4ER06dECzZs1w9OhRDBs2DP3798eGDRvMlqtUqRKCg4ONj127dpm9Pnz4cPz6669YsWIFtm/fjhs3bqBLly7cV2Rm57nbeBCbgIKervD3yc3cyYCCedyw/PV6+LF/XbPfX2kHTkT2gZ2rERE5mphI3F73AYZcbYq9t5Iu8E4FvovxHSshb24G3LagXbt26pFRc+fORalSpTBlyhQ1XaFCBRVUT5s2DW3atDEu5+TkBD+/1MdbDgsLw3fffYelS5eiefPmat7ChQvVuvbu3Yt69eqleE9MTIx6GISHh2dqO8k2rT9xUz23CfRj++5McHPWoWje/0q7l+y9jD9PBGPWSzV4M5TIDrDEm4jIgcRePYS70+rB59QiDLo/FT4eLpj7Sk18/WJ1Bt12bM+ePWjZsqXZPAm4Zb6pc+fOqerr/v7+ePnll3HlyhXja4cOHUJcXJzZeqQqevHixVOsx2DSpEnw8vIyPooVK5bl20bWJS4hEZv/TWp+0LZS6jdxKH3SPv7L9aexO+gOOs/ajaBQVtknsnUMvImIHEFiIoL//Aqa71ojX/RV3NDnw+ESfbFxeBM13A/Zt5s3b8LX17zNvkxLCfTDhw/VdN26dVW77/Xr12POnDmqevozzzyDiIgI4zpcXFzg7e2dYj3yWmrGjBmjSsoNj6tXr2bbNpJ12PuoUzW5qVerZD5LJ8dmebk746fX66OItzsu3XmA52fvxo6ztyydLCJ6CqxqTkRk52LvB+PGot4oeX+vmt6Cukh87msMr1nB0kkjK2Jadb1KlSoqEC9RogR+/vln9OvX74nWKR25yYMcx5+Pqpm3qugHnZbDiD2NioXzYN2Qhhi4+BAOXr6H3gv346NnK6J3g5Kswk9kg1jiTURkx87/8zeivq6ngu5ovTOWFRyOaiN/QSsG3Q5F2m0n731cpvPkyQN3d/dU3yMl2+XKlUNQUJBxHbGxsbh//36K9aTVLpwci16vx+ZTScdZO9akyRI+Hq74cUBddK1RFNLP2oRfT+GDtSdUXhORbWHgTURkp+0sp28+i84/3cTdBHecRXHsbbUKPd8cj/yebpZOHuWw+vXrY8uWLWbzNm3apOanJTIyEufPn0ehQoXUdM2aNeHs7Gy2njNnzqh24I9bDzkOGYLu16GN8HHnQNQvnd/SybEbrk46TO5eBe+3D4BGAxTLm4sl3kQ2iFXNiYjszLmzpzD8z1s4ESyd8bhiQcnJGPb8MyiX18vSSaMsIkGxoSRaSHtsGSYsX758qrMzaVt9/fp1/PDDD+r1gQMHYubMmRg1ahT69u2Lv/76S1Uh//33343reOedd9TY4FK9XIYJGzduHHQ6HXr27Klel87RpMr5iBEj1OdIafnQoUNV0J1aj+bkmHzzuOHVeiUsnQy7vKnxeuPSaFDaB5UK5zHOl5JveY2IrB8DbyIiOxEXn4Dty6ehwdkvUTe+G67l6oyJnQLRsUohXpjZmYMHD6oxuQ0kGBa9evVSHaTJGNymPZLLUGISZMs43F9//TWKFi2K+fPnmw0ldu3aNRVk37lzBwUKFECjRo3UMGHyv4EMP6bVatG1a1c1TJi8f/bs2Tm23USOLrDIfzdQo2LiVbvvQU1Lo3mAeeeJRGR9NHorbiQiva3KHXbpCVXurBMRUerOXb6G4B8HonHsTjV93L02fAf9ioJ5Um+/S5bh6Oc1R99+e3b8Whi+WH8anasXQbeaRS2dHIcwddNZfLPlnKp+PqZdAAY848+brERWfF5jG28iIhsWn5CIVWtXwX1BExV0x0OLkxWGI/Cd9Qy6iSjH/HEiGLuCbmPrmVDmeg4Z0qwMXqxdDFKE9tkfpzFq5T+IiU9g/j+haY9uZKRG5svrRE+DgTcRkY06F3wfy6cMRacj/VFUcxu3nPwQ3vM3VHphPDQ6tiQiopwhlSfXPxpGrG0l9nCfU1yctJjUpTLGdawIGbltxaFraD55G25HxqRYloFj+mT4O0MtguR5J/M5PB49LQbeREQ2WMo9Z9t5vD3zZ3SPWgYnTSKuFHkWPu/sR77yDS2dPCJyMGdCInDxdpQKBJsFFLR0chyKdKzWp2EpLOxTR+X/9fvRaDZ5G86FRBiXYeCYMW+1KIsRrcqpIHv6o9JtQ97JfHmd6GmwSISIyIYEhUZg5Ip/cOyqjKVcBD8XHIhn61RA8fqvWjppROSgDKXdjcsWgIcrLy0toUm5AvjjrWfQbc7fuP8wDisOXsP7HSrgy/WnMXvbebSvXAgl8ufCmiPXkJAIJOr1qqZCxUJeqFw0qcO2+w9isebIdSQkymtJyySo5YDERD2qFffGM2WTOlsMexCHOdvPq3XI8omPljc8apfMh07ViqhlI2PiMXadjD2OR8vqzf6v658f/RqVUstKVfl+iw4mfXaydMhn1PfPj9HtAozb3Wbajkev6VUaZZmk9yWtd9oL1YzL1p+0RaUlRTr0etQqkRfL36hvDK5Vyfdf59T6GHRTVuGvIxGRDZCLhEXbTsJ12wTExzWFp2sZjO1YEd1qtmdnOkRkUcZq5oGsZm5JZQp6YNu7TTFl01l8u/MCFv19CbESZUsb/OPB6pHc0OZljIH37chYTPj1VJrrl+DYEHhHxcZj7vbzaS4rAash8JZaWqsPX09z2VwuOuP/EghLXwFp8cvjajZ9LjRCfVZqkle5j4iOV4F36unVm7Wdl8Bb1ivVy1nSTVmFgTcRkZUF2Psv3kVoRDQKerqhTql8uHQnCjOWrcWbtz9DOe11NMt9GtrBf6NQXk9LJ5eIHJxUMT99MwJOWg1aVmA1c0vzzuWCjzsFYvn+qyrodtZpUL14XtUGXIJIrUajbtbqNFD/l/LJbXyvp5sTOlYtnLTso+UM75P/qxf3Ni6b29VJBeLaR+vRqnU/+l+jQWWTYc/cnHV4v32A+Wc/Wqd8TkmfXMZlXXRaTH+hmuqpXZZPSjOMyxZMFngv6V/X+Jnq87X//e/p5my27LohDSEjnhuX1/73v6vTf61vZ24NMjsnf7j2BD7pHJiFe4kcFQNvIiIrsf5EsCptCA6LNs7zdNOhW/yf+EL3I1y1cXjo6oPC3b+GhkE3EVkBGUu6URkfFeBJ0EeWJ+2SJeiWIFaeZf9kpNTWN48bZvSsnqHP8HJ3xkfPVszQshJ4v964dIaWlcBZhqTLqAalfTK8bOkCHukuY2jTPbxlWRy9eh9bz9zCkr2X4eXuhHfb/FfFnehJMPAmIrICQcvfx6l/QhCc0MU4Ly/C8WXCt2jldFhNR5dqCfdu84DcGb/QICLKToFFvFSpo7SvJctL3hmYYVqwynTm8u5eVCyenbEL1+8/xKyt59WNjLdblsuR/Uj2iYE3EZGFSVW2v87ewQjnlZBL1xkJXVBUcwsrXcbDT3NPLbNbUwP1Xlkhdf4snVwiolRLKsmyUuuB27SzMNNpSv1cbJp3eXO7YOZL1dFj3h7EJehx+ErS+ZjoSTHwJiKy4En+zM0IrDx0FQuinkOELh4jnVeq12YmdEaM3gnSIO2H+JYYG98Xyy7dQ/3S+bm/iMgq/Bscjny5XVQVZbK+wNHAMC2vU9qGt0pZmi3t499vXwHTN59D7wZJPa8TPSkG3kREOUSqrR25eg+HL99Xd85PXw2Ff9w51NCewzznpOef4puq4HuI01q4auLxTVxnTE3ood4vHa4REVmLcb+cVJ1Bfv1iNWMP1mRdgaMBS7qfXO8GJfFslcIo4GnesRuRVQXeO3bswFdffYVDhw4hODgYa9asQefOnbPzI4mIrIKULJwNiVABtgTaR67cw4XbUSilCcYrus0YpT2LippLcHFNMHvfRX0hVdItQbc8G4JuIb2cExFZg1sRMThw6a76v1bJfJZODlG2kR7VTYPukPBoFPBwZfMKsq7AOyoqClWrVkXfvn3Rpct/HQYREdmb+w9iceRKUkm2PE5evYMSsUGqFPtaYklc0FdQy1XMm4B+D/40vk/v4QsUrYOZ5/Ji2wN/NNYeMwbd8jxUtxozE7rAzytpaDEiImuw8dRNNeZy1aJeKOLtbunkEOWIv06HYPjyY3i9sT8GNyvDXCfrCbzbtWunHhkVExOjHgbh4eHZlDIioqcrzT4XGmGsMi6PsFs3VJBdU3sOb2vPoormAtxc49Tyx3yfx91mr6kxUL1d9MDGIBVso1htaLxLyO10lD0RjLhlH+Jt5zWYEtdNdbAmQbdUO5cuiyp2/ESNZ0pEZA3Wn7ipntsGFrJ0UohytKZH2MM4TNl4BjWK52W/K2S7bbwnTZqECRMmWDoZRERmwh7E4fDVezhyWYLs+zh+9Q6cYu7jDryMw34dcRuUItf07nmhKVoHVSu0AAIK/vdC+69SLNv2zmK0dV6Jb3UvYkb0c2qeBN+ebk4YgZ+AO+UBjOKeISKr+E3cc/6O+r9toJ+lk0OUY3rUKob9F+9h1eFrGLrsCP54uxGbgZFtBt5jxozBiBEjzEq8ixUrZtE0EZFjkbFoz4VGPmqbnVSafetWCGpopdr4WQzSnENV7Xkccy2HWUW/Une8a5TwRsIGf+ic3YCitYFidYFidaDJX0aVZmfsgxOAZh+g3zPvovLFu6ojNWnTXadUe2Bn6aTXiYiswOZ/QxCfqEeAnydK+eS2dHKIcrS99yedA3HiehjOhETgrWVHsKRfXThxqE+ytcDb1dVVPYiIcrLkRvU0fiWpA7SjV+4jIiZevfaR02K8rv0HZd2up3hfgzx30LB/3f8C6zJ7Aaen+P1qNkY96YCUVdeasKSbiKzHhpNJ1czbVGJpNzkedxcdZr9SA8/N2IW9F+6qocbeaSO10ohsKPAmIsru0uygW5HGkmwJtoNDb6GalGZrzqGj5hZ2xr+BXC46VC3qjRZRd1Ay7FHQna+0KsVWj6J1oClYwbw0+2mCbiIiG/JV96po+28IapbIa+mkEFlE6QIe+LxrFVXdfObWIDQs48P23pQuBt5EZLekA5SjV+8bA235P090MOpoT6Om9ix6a4NQ3vUKdBq98T1V+kxDmZKlkqqNnX8fiHuYFGzn9rHothARWQsvd2d0qVHU0skgsqiOVQurcewT9HrVeSqRRQPvyMhIBAUFGacvXryIo0ePIl++fChevHh2fjQROWBp9nkpzX40brY8X711F5VxAUf1ZRD36OfuA5df8aJ2s/mbvYqrHsalbXZA4XyAoa1W6WYW2BIiIiKyBROeq8TxvMk6Au+DBw+iWbP/LlwNHaf16tULixYtys6PJiI7Fx4dp9pjG6qMH71yD7mjQ1RJtgzr1VN7FpVcLsNZk4BpJefAp3wDVC+eFxVuRwEHwowdoKlhvfJwOBwiovRExyWg98L9aFq+IPo0LAlXJ+mVgshxaU2G+ZShRnecu4Vm5U1GMSHKqcC7adOm0Ov/q8JJRPSkpdkXbkeajZstPY8bfl5aaQ9ig/MiFHK7m/LNHr4YXj8vUL5k0nSRHkDVHtwRRESZtPPcbdWZ1JU7D/BGY3/mH9Ej8QmJ6LPogPqOzH65BtpX5g19SoltvInI6kREG9pmJwXa0tu4a/RtVZJdXXsOXbVn8Z2mPU7lbYoaxb3RNk9lFNp/F3qNDhq/yo86QaubNLSXd/GMD+lFRERp+vNEsHpuE+inhlUioiTSL0zFwnlU4D1q5T+oWCgPSnKoPUqGgTcRWUFpdpQxwJZg+2xoBPLoI9FRtwedtWcxUXMOJdxCzd5XqW5j5Or0qClLXAWgwm/QFKkBuHBMWSKirBaXkIjNp0LU/+0CWZpHlNy7rcvjyOX72H/pLgb9eBhr3mwAN2c2x6D/MPAmohwvzT52NcxYZfzIlfvAw3uqJDsarjiTWFEt5++twSfRC43v00MDTcGKxk7QcpVo8N9Knd2AUs9wTxIRZZM95+8gPDoePh4uHEaMKI1S7296VkeHb3bi3+BwjP/lpBpyjMiAgTcRZRvp40GVZqvhvO6rEu2zIWEojRuq2nh7zVl8qD2HMm431PJBXg0Q1OpV1CjhjYKebsCqjUD+MqrquKZITcDNi3uLiMgC1p+8qZ5bV/KDzqRDKSL6j5+XG75+sTpeXbAPPx24itol86FrTQ69R0kejZlDRPT0ImPisTvoNmZsOYc+C/ej+seb0GbKFry78h8s238FZ26GYbfLW9jkOgpfOP8PPZy2o4w2KehG/rIoU6Ea2gb6JQXdout8oOlooHRzBt1EJnbs2IGOHTuicOHCqq3t2rVr082fbdu2oUaNGnB1dUWZMmVSjC4yadIk1K5dG56enihYsCA6d+6MM2fOpOg0VT7P9DFw4EDuGzsnvTVvfBR4twv0s3RyiKxao7I+GNainPr/k99PISom3tJJIivBEm8iBycXVPsv3kVoRLQKeOuUypeh0gwpzb6o2mY/6mn8spRmh6M4bqKG5hxaas9hlPYcdK6JeN/vf6hRIq/qCC3/3gAg5CggJdimnaDlypcj20tkD6KiolC1alX07dsXXbp0SXf5ixcvokOHDipI/vHHH7Flyxb0798fhQoVQps2bdQy27dvx+DBg1XwHR8fj/fffx+tW7fGqVOnkDv3f30nDBgwABMnTjRO58qVK5u2kqxF+MM4VXInnV7W889v6eQQWb2hzcsgJCIar9QtgdyuDLcoiUZvxeN9hYeHw8vLC2FhYciTJ4+lk0Nkd9afCMaEX08hOCzaOK+QlxvGdayItsk6z5E7tseu/jdutlQbv/cgTr3WXbcNrbUHVfXx/JqIlB/03mXA3Tvp/4gQIFd+QMcTETme7DivSanzmjVrVAl1Wt577z38/vvvOHHihHHeiy++iPv372P9+vWpvufWrVuq5FsC8saNGxtLvKtVq4bp06dnKG0xMTHqYbr9xYoV43ndRsmNWlYzJyJ6svM6r3yJHFTQ8vdx6p8QBCeYl5bdDIvGqWUfwq+8D85XGmoMtKWaeCF90pBeDbXnsT3+Jbg4OaNyES+8knAdVW8fTlqBzhUoXM2kNLvOf0G38PTN4S0loj179qBly5ZmGSEl3cOGDUszc+QiQuTLZ14bRUrMlyxZAj8/P1Xd/aOPPkqz1Fuqr0+YMIE7wE4w6CZ6MlJYcelOFJ6vzvbejoyBN5GDllr8dfYORjivhFR5mWESfA/RrVbzp5/pgu3/rkQN7VkM0Z5DTZdz8NPcMy7XsMtg+FdpCBcnLXAhFghpmBRkF6oCOLlaaMuIKDU3b96Er6/5TS+Zljv1Dx8+hLu7u9lriYmJKihv2LAhAgMDjfNfeukllChRQrUt/+eff1RJurQDX716daqfO2bMGIwYMSJFiTfZjuCwh3gYmwD/Ah6WTgqRTTpxPQw95u2RsVlQuoAHqhQ1KYwgh8LAm8gBSZvuz6KeQ4QuHiOdV6p5PyU0w6u6TXjLeS2mxHVDIrRY4zrO/I1aJ8CviirNDihRGJCgW/g3TXoQkV2Qtt5SLX3Xrl1m819//XXj/5UrV1ZtxFu0aIHz58+jdOnSKdYjHbnJg2zX939fxtzt59G/USl8+GzScI9ElHGVCudB0/IFselUCN788TB+H/oMvHI5MwsdEANvIgckHanhUUm3K2JV8G0IwCXolvn1tScR45IPrqXqJVUbl9LswtUBF3akRGRrpFp4SEiI2TyZlvZoyUu7hwwZgt9++031nF606OOrRdatW1c9BwUFpRp4k22TboCkLxBRrThL6YietB+Oyd2r4tkZO3H17kOMXHEM/3utpppPjoXDiRE5IMNwXYVwB610j9pmA4jXa43VzvcmVsDhHgeAnsuARsOBkg0ZdBPZqPr166uezE1t2rRJzTcNsiTolo7a/vrrL5QqVSrd9R49elQ9S8k32Z8zIRG4dOeBalLUrHxBSyeHyGZ5uTtj9ks14aLTYvO/Ifh2xwVLJ4ksgIE3kQO6fu8BymquYZXrOJTXXlPzYvU6OGkSMVS3GnIP1s8rF+pw2BgiqxQZGamCXkPgK8OFyf9Xrlwxtq1+7bXXjMvLMGIXLlzAqFGjcPr0acyePRs///wzhg8fbla9XDpNW7p0qRrLW9qFy0PagAupTv7xxx/j0KFDuHTpEn755Rf1GdLjeZUqVXI8Dyj7/Xk8aezuxmULcEgkoqdUuagXxnZMaq7x5YYzOHDpLvPUwbCqOZEDkRKteTsuYPP6tVjpMhlemgdq/rdx7fFZwisq6JYq5xJ4V+z4CXuwJbJSBw8eRLNmzYzThg7MevXqhUWLFiE4ONgYhAspvZbhxCTQ/vrrr1UV8vnz5xvH8BZz5swxDhlmauHChejduzdcXFywefNmNZSYjCMunaR17doVH374YQ5sMVnChpNJgXfbQD/uAKIs8HLd4irgXnf0BtYcuY7aJc1HjSD7xnG8iRxEYqIeH/9+Cht3H8AW13fgpkkag/t7XReMi+pmXO793L/g9YSfgGYfAE1GWTDFRPYnO8bxtiWOvv225OLtKDSbvA1OWg0OftgS3rlcLJ0kIrsQFROPX47dwIu1i7Gdtx3gON5EZCYmPgEjfz6G3/6RTnIK4FSp3qgRsRWo9DxeafoByl28qzpck7bfdUq1B3aWBhITmItERA5e2l2/dH4G3URZKLerE3rWKc48dUCsak5k5yKi4/DGDwdx5MINOOvc8VW3qqhRrT2gTwS0OugeXViZYUk3EZFD692gJPx9csPDjZeKRNlZ+v3h2hN4vnoRNC5XgBlt5/hrSmTHQsOj0WfBXrx8ezpGuV5D1Iur0bBCkaQXNRJyExERpeTmrEPrSmzbTZSdpN8daeu9/ewt/P5WIxTyMh/ekewLezUnslPnb0Wi5+ytGHZnIl5y2oqq2vNoqDtt6WQREREREYA3m5ZGxUJ5cDcqFkOWHkFcQiLzxY4x8CayQ0eu3EPf2RvwxYOxaKU7hESdGzQ9FgPlWls6aUREZOXeWXEMkzecUbWmiCh7a5bMeaUGPF2dcOjyPXy5ngUk9oyBN5Gd+et0CEb+73fMT/gItbRnkejqBe1ra4EKz1o6aUREZOWko81Vh69h5tYgxCXqLZ0cIrtXIn9ufNW9ivr/fzsvYuOjjg3J/jDwJrIjPx+8iq8Wr8VS7Ycoq72ORM/C0PbbAJSob+mkERGRDdh0KgR6PVC1qBeKeLO9KVFOaBtYCP0alVL/j1xxDFfuPGDG2yEG3kR2QK/XY9bWIIxa+Q+iE3XwcEqE3icA2v6bgIIVLJ08IiKyEetPJJW2tQlkx2pEOem9tgGoXtwbrk463I6KYebbIfZqTmTjEhL1mPDrSfyw57KabtO4EXJX/x0ar6KAe15LJ4+IiGzE/Qex2HP+jvq/XWAhSyeHyKG4OGkx5+Wa0GqBgp5ulk4OZQMG3kQ2LDouAcOXH0X+fxejibYgmrTvib6PqioRERFlxuZ/QxGfqEeAnydK+eRm5hHlMD8vtxTXedIBG9kHVjUnslFhD+Pw2nf7UOn01/jEeSG+c5+BvpU0lk4WERHZqPUngtVzG47fTWRxvx67gWe+3Iqg0AhLJ4WyCANvIht0MywaPefsRLdrn2OI0zo1z6nxCMC7hKWTRkRENlza5p3LGe0qs303kaX77vnpwBXciojBoCWH8SA2njvEDjDwJrIxcufzpVlb8M69CejhtB16jRbo+A3Q5F1AwxJvIiJ6Mp90rowDH7REeV9PZiGRBWk0Gkx/oToKeLriXGgkPlxzQgXjZNsYeBPZkEOX76Lf7A2YEj0WzXVHkejkBs2LS4GavSydNCIisgPOOq266Cciy5Kge0bP6tBqgNVHruOnA1e5S2wcA28iGxpb9aX/7UOX+N9QXRuERLe80Pb6FSjfztJJIyIiGyYdOB27ep8lakRWpp5/frzTprz6f9wvJ3Hiepilk0RPgYE3kQ1Ytv8K3lh8EDHxifjH/w3EVe8Nbb+NQLE6lk4aERHZuB1nb6HTrN3oMW+PpZNCRMkMbFwaLQIKIjY+EYOXHkZ4dBzzyEZxODEiKybteb7ZEoSNWzZCoy+G7jVL4LMuleGsq2/ppBERkZ1Yf/Kmeg4s4mXppBBRMlqtBlN6VEWHb3ahdUVfuHN4MZvFwJvISiUk6vHRuhMIO/AzVrvMxmnfZ1Gl60JotKyoQkREWUNK0TafClH/t+UwYkRWyTuXC9YPewaebs6WTgo9BV7BE1lpe7tBSw7B5eC3mOE8A66aeFT10UOjT7B00oiIyI7suXAH4dHx8PFwQa2S+SydHCJKg2nQHZeQiMt3ophXNoaBN5GVuf8gFq/8by+qn52O8c4/QKvRA7UHAN0WAjre6SQioqyz/kRSNfPWlfygk+6TiciqhUZE48Vv96Lnt3txLyrW0smhTGDgTWRFbtx/iBfn7ETP4EkY5PRr0swWY4H2XwFanaWTR0REdtakadOppMCb1cyJbIO08b4bFYsbYdEY/vNRJCZyfG9bwcCbyEqcDYlAl9l/4637n6Orbif0Gh3QaTbwzEiAY6oSEVEWO3jpLm5HxiKPmxPql87P/CWykSrns1+uAVcnLbaduYXZ24IsnSTKIAbeRFZg/8W76Dbnb9wMj8ZOjzZIdPGEpudPQPWXLZ00IiKyUzVL5MXSAXUx/rlKcNbxkpDIVlQolAcfdw5U/0/ddBZ/n79t6SRRBuTIr+ysWbNQsmRJuLm5oW7duti/f39OfCyRzbSve/W7PapzmxrFvTFqyFvQDj8OlGtt6aQREZEdc9Jp0aC0D7rUKGrppBBRJvWoJcPMFoXUNH9r2VGEhkczDx098F6+fDlGjBiBcePG4fDhw6hatSratGmD0NDQ7P5oIqu3ZO9lzFq6Emu17+GlMvH4sX895M3tArjntXTSiIiIiMiKTewUiAA/T9yOjMHo1cctnRyydOA9depUDBgwAH369EHFihUxd+5c5MqVCwsWLEixbExMDMLDw80eRPZIr9dj6sYzWP/LMixz/hgVtFfxiccKuLuwAzUiSt+OHTvQsWNHFC5cGBqNBmvXrk33Pdu2bUONGjXg6uqKMmXKYNGiRZmuoRYdHY3Bgwcjf/788PDwQNeuXRESkjQGNNmW/+24gPG/nMSZmxGWTgoRPSG5bpz1cg3UKpEXH3aowHx05MA7NjYWhw4dQsuWLf/7QK1WTe/ZsyfF8pMmTYKXl5fxUaxYsexMHpFFxCckYvSq47i8bREWOn8JD0009KUaQ9t5NvcIEWVIVFSUqkEmgXJGXLx4ER06dECzZs1w9OhRDBs2DP3798eGDRsyVUNt+PDh+PXXX7FixQps374dN27cQJcuXbjXbPDm74/7LmPR35dwLpSBN5EtK13AAysG1od/AQ9LJ4XSodHLr282kRNykSJF8Pfff6N+/frG+aNGjVIn7H379qUo8ZaHgZR4S/AdFhaGPHnyZFcyiXLMw9gEDFl6GKXOLcSHzj8mzazUBXh+LuDkyj1BZOfkvCY3lrPyvCYl3mvWrEHnzp3TXOa9997D77//jhMnThjnvfjii7h//z7Wr1+vpqWEu3bt2pg5c6aaTkxMVOfgoUOHYvTo0SrNBQoUwNKlS9GtWze1zOnTp1GhQgV1M71evXoW2f4HsfFZsh5HIqXcz8/+Gy5OWux+rxlyuzpZOklElEX2XbiDovlyoYi3O/M0Dblcsu43LzPnNav6pZXqb/Igskf3omLRb9E+tAuejQHOfyTNrDsIaPOZVAWxdPKIyI5JYGxa+0xIabaUfJvWUBszZkyaNdTk9bi4OLP1BAQEoHjx4mkG3qndUM9qFcf+V2pPmRMbn4jan25hthGRQ7n0eQeLfG62Xu37+PhAp9OlaP8l035+ftn50URW5dq9B+g692+cvHob9ZzOJs1sNRFoO4lBNxFlu5s3b8LX19dsnkxLIPzw4UPcvn0bCQkJqS4j7zWsw8XFBd7e3mkukxybkBEREeVAibecoGvWrIktW7YYq8BJ1TWZHjJkSHZ+NJHV+Dc4HL0W7EdoRAwKeeWBe8/VQNQRoFLa1UKJiOyBlKBLu/HkTciy0qmJbbJ0ffbu0u0otP9mF5y0Gux8rxm83J0tnSQiykLbz9zCoB8Pq/+n9qiKtoEs7LQW2V7VXE64vXr1Qq1atVCnTh1Mnz5ddQojvZwT2bs95+9gzA+b0Tx+Pw77Pofv+9ZBIS9pc1PC0kkjIgcitcxSq30m7dHc3d1V7bT0aqjJs1RJl3bhpqXej6vFlhNNyLKyrZ4j2Hb2lnquXzr/o/MREdmTdpULYVDT0piz7TzGrjuJasW82fGalcj2hqUvvPACJk+ejLFjx6JatWqqN1XpyCV5dTYie/P7P8EYu2Advtd/iM+d52Ntg8u8yCEii5AOTqW2malNmzYZOz41raFmYKihZlhGXnd2djZb5syZM7hy5YpZB6pk3VyddCjk5YZ2gYUsnRQiyiYjW5VDnVL5EBkTjzd/PIzouATmtRXIkdvEUq2cVcvJkSzafRFrfv8Vy5y/go8mHIneJZGrTENLJ4uI7ERkZCSCgoLMhguTG9v58uVTnZ1JFe/r16/jhx9+UK8PHDhQ9VYuo4r07dsXf/31F37++WfV03lGa6hJr639+vVTy8nnSGm59HguQXdGejQn69CvUSn0bVgS8YnZNqgNEVmYk06LmT2ro/03O3H6ZgTWHrmOF+sUt3SyHB7rZxFlIRmd76sNZ3Byx2osdZ6O3JoY6AtVhfbllYBHQeY1EWWJgwcPqjG5DQztqCVwXrRoEYKDg1VJtEGpUqVUkC3jcH/99dcoWrQo5s+fr3o2N62hduvWLVVDTTpLk1pqyWuoTZs2TfV23rVrV9Vbubx/9uzZ3Ks2Roagc9ZpLJ0MIspGBfO44ZsXq+PinSi8UDtr+9YgKxzH+2llx3ifRNklLiERo1cdR+LRZfjS+Vs4axKg928GzQuLAVdPZjwROfx5jed1y/rn2n1ULJRHlYYREVHOntf4y0uUBR7ExmPADwdx/MgeTHOZo4JuVO4BzUs/M+gmIiKLC42IRqdZu1Hnsy2IiI6zdHKIKIeFPYjDuHUn+P23IFY1J3pKdyJj0HfRARy7FgY35xI4X3k4SnvGAy0ncoxuIiKyChtPhkDqOBbLlwuebhxCjMjRvL74IPZdvIs7UbGY0bO6anJCOYsl3kRP4erdB+g5ZwcuX7sG71zOWDqgHkp3GQe0/oRBNxERWY0NJ2+q57aVOKYvkSMa1TYATloNfvsnGIv3XrZ0chwSA2+iJ3Tiehhenb0J48PHYpn7V1jVrypqFM8rvdYwT4mIyGrcfxCLPefvqP/bBjLwJnJENUvkxeh2Aer/j387hWNX71s6SQ6HgTfRE9gddBtDvv0Ts2M/QgPdKZR3CkZpXGNeEhGR1dl0KkQNHxbg54lSPrktnRwisuBwglLrJS5Br8b3lptylHMYeBNl0i/HbmDCwrVYgg9QUXsZibkLQtv3T6BITeYlERFZbzVzlnYTOTRp1/1l9yookT8Xrt9/iJE/H0NiotUOcGV3GHgTZcJ3uy5iwU8r8JPTOBTV3EZivtLQ9tsIFKrKfCQiIqsTGROPHeduq//bBRaydHKIyMLyuDlj1ks14OKkxb/B4QiJiLZ0khwGezUnygC5G/jF+tM4sWsdlrlMgbsmFvrCNaB9eQWQ24d5SEREVim3iw6rBjbA7vO3Uc7Xw9LJISIrEFjEC/NerYlqRb2RN7eLpZPjMBh4E6UjNj4R7636B2uOXEcxTUHoXTyhL1Edmu7fA668iCEiIuuuWlq5qJd6EBEZNCtf0Cwz9Ho9hxjLZgy8idKpojdoySHsPHcbOq0Gb3VphVz+TQGvYoCO46ASERERkW37+cBV1RfEt6/VUte7lD3YxpsoDbciYvDyvN1ofnEK2jkfxfxetdC9VjEgnz+DbiIisnrbz97COyuO4e+gpDbeRETJhYRHY/yvJ7HldCi+3nyWGZSNGHgTpeLynSi8NGcb3rj1Cfo4bcBM15loVoR3AImIyHasO3IdKw9dw6Z/QyydFCKyUr553DCpS2X1/4ytQeqGHWUPBt5EyRy/FoZeszfhk8ixaK/bD73WBbrOswCPAswrIiKymf5JNj8KuNmbORE9TqdqRfBy3eLQ64FhPx3BjfsPmWHZgIE3kYkdZ29h6Le/Y27ch6irPY1EF09oXl0FBHZhPhERkc3Ye+EOwqPj4ePhgpol8lo6OURk5T56tiICi+TBvQdxGLrsCOISEi2dJLvDwJvokTVHruHTRWvxo+ZDBGivItHDF9q+fwKlGjOPiIjIpvx54qZ6bl3Jj50lEVG63Jx1mP1STXi6OeHQ5Xv44s/TzLUsxsCbHJ4Mn/DtjvMYvvwYumi3oojmDvT5y0LbbxPgl9TmhYiIyFYkJOqx6VRS4N0u0M/SySEiG1E8fy5M7l4V0rF5blcndY1MWYfDiZFDS0zU49M//sV3uy6q6Vt1x0CfqwI09d4Ecue3dPKIiIgy7eClu7gdGQsvd2fU8+e5jIgyrk0lP2wZ2RSlfHIz27IYA29yWDHxCXhnxT+IOP47nFAZ77WvjAGN/QGwlJuIiGzXg9gElCnogapFveGsY+VGIsoc06A7Oi7BWBWdng4Db3JIEdFxeOOHg6h5eT5GuqzElWKdUfyZ5yydLCIioqfWLKCgehgumImInnR43Td/PIwqRb2NQ47Rk2PgTQ4nNDwafRfsxYu3v8ErzlvUvOIly1g6WURERFmKJVRE9DSu3H2AU8HhOHkjHHVK5cXz1YsyQ58C6x+RQ7lwKxIvzt6KoXc+xitOW6CHBmg/GWjxEaDRWDp5RERETyUoNIIl3USUJZ4pWwBvNS+r/n9/9QmcC4lgzj4FBt7kMI5evY++czbiiwdj0UZ3EHqdKzQ9fgDqDLB00oiIiJ6a9EDc//uDqPHxJhy6fJc5SkRP7a0WZdGojA8exiVg0I+HERUTz1x9Qgy8ySFsPROKnt/uwdT4T1FbexaJrl7QvLYWqMh23UREZB/OhETg0p0HajixAL88lk4OEdkBnVaD6S9Wg28eVwSFRuKDNcc5zNgTYuBNdm/loWuqBOBhXCI2+fZDoncJaPuuB0o0sHTSiIiIssyfx5PG7m5croAag5eIKCv4eLhi5ks1VBC+9ugNLD9wlRn7BPirTHZd5W7O9vP4ev1xJMAFz1cvguFd20GL/oCTi6WTR0RElKXWn0gKvNtW8mPOElGWql0yH0a1KY8/TtxEo7I+zN0nwMCb7JJUs/v4t1MI3rsCW12/x69V52BA56rQaqUDNQbdRERkf52HSlVzJ60GLSv4Wjo5RGSHXm/sjz4NS8HFiZWmnwRzjeyOjFv61rIjiNs3H7Odp6Ow5i7ecN30KOgmIrIPs2bNQsmSJeHm5oa6deti//79aS4bFxeHiRMnonTp0mr5qlWrYv369WbLyLo0Gk2Kx+DBg43LNG3aNMXrAwcOzNbtpIxZfzKptLt+6fzwyuXMbCOiLCe/+aZBt3RcLDVMKWMYeJNdCY+OQ+8F+1Du32/wqfMC6DR6oGZvoO0Xlk4aEVGWWb58OUaMGIFx48bh8OHDKpBu06YNQkNDU13+ww8/xLx58zBjxgycOnVKBcvPP/88jhw5YlzmwIEDCA4ONj42bdqk5nfv3t1sXQMGDDBb7ssvv+SetQIbHlUzbxdYyNJJISIHMHXTWXSetRvf7bpo6aTYDAbeZDdCwqPx4pxd6Hz1C7zttCZpZtMxwLPTAR1bVRCR/Zg6daoKgPv06YOKFSti7ty5yJUrFxYsWJDq8osXL8b777+P9u3bw9/fH4MGDVL/T5kyxbhMgQIF4OfnZ3z89ttvqoS8SZMmZuuSzzFdLk+etHvPjomJQXh4uNmDsse0F6phVNvyaF2J1cyJKPsV8Ehquvn5n6c5fGEGMfAmuyDDG/SctRUj7k7Ai07boNdokwLupqOlXoylk0dElGViY2Nx6NAhtGzZ0jhPq9Wq6T179qQZAEsVc1Pu7u7YtWtXmp+xZMkS9O3bV1UtNPXjjz/Cx8cHgYGBGDNmDB48eJBmWidNmgQvLy/jo1ixYpncWsoo/wIeeLNpGdX7MBFRdnulXgl0rFoY8Yl6DP7xCO5ExjDT08HAm2zeocv30G3u37geFg0/54dI1LlB02MxUKuPpZNGRJTlbt++jYSEBPj6mpdsyvTNm0nVjZOTauhSSn7u3DkkJiaqauSrV69WVcVTs3btWty/fx+9e/c2m//SSy+pgHzr1q0q6JaS9FdeeSXNtMoyYWFhxsfVqxyChojIHshN2UldKsO/QG7cDI/GsOVHVefGlDbWvyWbtuXfEAxeehjRcYmoWrQACr+wDtroq0Cx2pZOGhGR1fj6669V1fSAgAB1sSRVyKWaelpV07/77ju0a9cOhQsXNpv/+uuvG/+vXLkyChUqhBYtWuD8+fNqncm5urqqB2Wf0IhojF17Eu0q++G5qoVT1FAgIsouHq5OmPNyTXSatQs7z93GrK1BeKtFWWZ4GljiTTZr+YErmLJkNV5LXIem5Qtg2ev1kK+AH4NuIrJrUs1bp9MhJCTEbL5MS5vr1Ej7bSnFjoqKwuXLl3H69Gl4eHio9t7JyeubN29G//79002L9KYugoKCnnh76OlsPBmiejRfsPsSg24iynHl/TzxTNkC6v/pm88iKDTC7PVvtpzDtE1nuWcYeJMtkmELZmw5hzVrluMnpwl433kZ5lc7j1wurMBBRPbPxcUFNWvWxJYtW4zzpPq4TNevX/+x75V23kWKFEF8fDxWrVqFTp06pVhm4cKFKFiwIDp06JBuWo4ePaqepeSbLGPDo2HE2gWmftOFiCi7VS7ipZ7bVPJDmYKeZkG39H6u45C+CiMVsinSdmTsuhO4d+BnfO88G66aeOiL14dTQFtLJ42IKMfIUGK9evVCrVq1UKdOHUyfPl2VZkv1cfHaa6+pAFs6NxP79u3D9evXUa1aNfU8fvx4FayPGjXKbL0yTwJvWbeTk/klglQnX7p0qeoNPX/+/Pjnn38wfPhwNG7cGFWqVOHet4D7D2Kx5/wd9X/bSgy8icgyDNXLJciWYFumDUH3iFblWP38EQbeZDOi4xLw9k9H4Hv6B8x0/gFaGaM74Flous4HnN0tnTwiohzzwgsv4NatWxg7dqzqUE0C6vXr1xs7XLty5Yrq6dwgOjpajeV94cIFVcVcgmfpGM3b29tsvVLFXN4rvZmnVtIurxuCfOmhvGvXrmq9ZBmb/w1VPQoH+HmipE9u7gYisorge+ZfQYhNSGTQnYxGL/V2s8Gnn36K33//XVVDk5O19I6aWTLepww/Ij2hPm6cULJ/YQ/i0P/7/WhyfR6GOK1LmlmrH9D+K0Crs3TyiIgyxNHPa46+/Vmt//cHVPA9rGVZDGtZztLJISJCuQ/+VEG3i06Ls5+2s/scCc/EeS3bOleTMUC7d++OQYMGZddHkIO4cf8hus/7GwlX9v8XdDf/EOgwhUE3ERE5pMiYeOw4d1v93y6QbeyJyPKkerkh6JZnmaYcqGo+YcIE9bxo0aIMvycmJkY9TO8gkGM7GxKBXgv2IzgsGr55KiOkxofwLegL1HjN0kkjIiKymJDwaFQslAfh0XEo5+vBPUFEFpW8TbdhWnCIMSts4y2dwBgCdqIDl+7inUVbEB8dg9IFiuL7vnXgm7clM4aIiBxe6QIeWDu4IR7GJnAYMSKyqNQ6UjNt82067cisKvAeM2aM6qnVtMRbOm8hxxwe5ctlG7BQ+xk0Hrng3Wcz8ubNZelkERERWRV3F/ZzQkSWH3Uotd7LDdPyOmUy8B49ejS++OKLxy7z77//IiAg4Iny1tXVVT3Isf247zKWrfsNy5y/REHNfSTmLgYtwgDkt3TSiIiIrKLvk9wuTvDK5WzppBARYXirtDt3ZEn3EwbeI0eORO/evR+7jL+/f2ZWSWQkHexP33wOB7auwTLnafDUPIS+YCVoX1kF5GHHMURERGLyhjP45dgNjHuuEl6tV4KZQkRkb4F3gQIF1IPoaUmVk/0X7yI0IhoFPd1Qo7g3xv96EpEHl2OR8xy4aBKgL9kImheXAm5ezHAiIiIZNSY+EZv/DTGO301ERA7exvvKlSu4e/euek5ISFDjeYsyZcrAw4O9bzqy9SeCMeHXU6qncgNXJy06JG7DDJe5STMqdoamy7eAE5seEBERGey5cAfh0fHw8XBFjeJ5mTFERI4eeI8dOxbff/+9cbp69erqeevWrWjatGl2fSxZuaDl7+PUPyEITuhiNj8mPhEBuiuI0eaCa61XgbafA9psG2aeiIjIJq0/cVM9t6nkC51WY+nkEBFRBmVbZCPjd0ub3eQPBt2OXb38r7N3MMJ5JYbqVj+am9TLoUy/7vwHfta0RkIbBt1ERESpnUc3nUoKvNsG+jGDiIhsiFUNJ0b2Tdp0fxb1HCJ08RjpvBIuiEeg9iLC9bnQyWkPpsR1w4zoLihz6R7ql2YP5kRERKYOXLqL25Gx8HJ3Rj1/nieJiGwJA2/KMdKRmpiR0AV5NFEY6rzW+NqMuM5qvulyRERElLKaeauKvnDWsTkWEZEtYeBNOebq3QdwQwwGOf2C13SbjfPj9DpMSehhnJZezomIiMjcm01Lo3SB3KhYOA+zhojIxjDwpmx3KyIG4385gYSTv2Cz6xIU1dw2vhar16mhw6SN98yELvDzckOdUvm4V4iIiJIpmMcNr9YvyXwhIrJBDLwp20hneqsPX8fHv5+C58Nr2OryDZw0iapNdx7Ng6Q23QldVNAtbb6lb9aKHT9hL61ERERERGRXGHhTtlUr/2j1EWwLuq+mCxcqi3vFB6LA/X+Q5/IufKt7ETOin1OvSfDt6eaEEfgJuFMewCjuFSIiIpMb2SN/PobqJfKia40iyOXCyzciIlvDX27K8qFOFu2+gHOb5mOS5icMcBqN9i1bYMAz/nDWPQNsnQT4N0G/Z95F5Yt3VUdq0qa7Tqn2wM7SQGIC9wgREZGJ0zcjsPrIdfx+PBhdqhdh3hAR2SAG3pRlztyMwLc/rcLLd2egnzZIzVsWeBCeTd/4b6FmY9STDkg5ZFgTlnQTEREl9+ej3swblyuA3K68dCMiskX89aanFhOfgO82HkK+PZ/jK+1f0Gr1iNPlgq7ZaHjWG8QcJiIiegobHgXe7QL9mI9ERDaKgTc9lUOX7+GvZVMx4OF38NZFqXkPA7rCvf2nQJ5CzF0iIqKncOFWJM6ERMBJq0GLAF/mJRGRjWLgTU8kMiYekzecwfd7LqG39h68naMQ5hWAPM9PhXvJhsxVIiKiLKxm3qCMD7xyOTNPiYhsFANvyrTdR/7Bd3/uw1/hhdV0VNU+iCpZD161egJaab1NREREWWHDyaTAu20lVjMnIrJlDLwpw+6GRWD3ko/RPHQRPtJ746L3DEzsWgPPlC0AoCZzkoiIKIv7UPFyd4aLkxatKrKaORGRLWPgTRkaP3Tvxp9QeM8EdEQwoAGcPArgjz4BcPeRoJuIiIiymquTDov71UVUTDx7MycisnEMvOmxQi79ixvLh6H+w71q+q7GGxGNPkKJZn0BrZa5R0RElM04hBgRke1j4E2pSkzUY91f29F+Zzf4auIQp9fheNEXEfjSZ8iX25u5RkRElI3Co+PwICYBfl5uzGciIjvAIktKISg0Ej3m7cHwzZHYk1gRx1yq43rPzagxYDZcGHQTEVmFWbNmoWTJknBzc0PdunWxf//+NJeNi4vDxIkTUbp0abV81apVsX79erNlxo8fD41GY/YICAgwWyY6OhqDBw9G/vz54eHhga5duyIkJCTbttGR/XL0BupN2oIxq/+xdFKIiCgLMPAmo7jgkzg/ozNe/vp3HLx8D7ldnHC91VxUfu8vlAyowZwiIrISy5cvx4gRIzBu3DgcPnxYBdJt2rRBaGhoqst/+OGHmDdvHmbMmIFTp05h4MCBeP7553HkyBGz5SpVqoTg4GDjY9euXWavDx8+HL/++itWrFiB7du348aNG+jSpUu2bqujWv9oGLHi+XJbOilERJQFNHrpOctKhYeHw8vLC2FhYciTJ4+lk2O/osNw69cJyHdyIXRIxJL4FthcejQ+fb4yini7Wzp1RER2I6vOa1LCXbt2bcycOVNNJyYmolixYhg6dChGjx6dYvnChQvjgw8+UKXVBlJa7e7ujiVLlhhLvNeuXYujR4+m+pmS5gIFCmDp0qXo1q2bmnf69GlUqFABe/bsQb169VK8JyYmRj1Mt1/SyfP6491/EIuan2xGQqIe295pipI+DL6JiGz9vM4Sb0eWmIiYgz8gcnJVFDj5nQq6/0JtFGz7Hhb2rs2gm4jICsXGxuLQoUNo2bKlcZ5Wq1XTEgCnRoJfqWJuSoLu5CXa586dU0G6v78/Xn75ZVy5csX4mnymVFk3/Vypil68ePE0P3fSpEnqgsTwkKCb0rfpVIgKugP8PBl0ExHZCQbejur6YYTPbg7X34bCI/4ezicWwtyiX6LqO7+jdaO6qm0fERFZn9u3byMhIQG+vubjOsv0zZtJ1ZOTk2roU6dOVYG1lI5v2rQJq1evVtXJTUvRFy1apNp+z5kzBxcvXsQzzzyDiIgI9bqs28XFBd7e3hn+3DFjxqhSAMPj6tWrWZAD9m/DyaT8bBvoZ+mkEBFRFmGv5g5ahe3kyq/R8N4RROrdsMipBwK7v4eBlYpaOmlERJQNvv76awwYMECVUMuNVelkrU+fPliwYIFxmXbt2hn/r1KligrES5QogZ9//hn9+vV7os91dXVVD8q4yJh47Dh3O2mfBBZi1hER2QkG3o4iIR766Pv443wcxv1yEnGR7THKOQLBVYdiYMdn4OHKQ4GIyBb4+PhAp9Ol6E1cpv38Ui8hlbbZ0n5beiW/c+eOqk4ubcGlSnlapGS7XLlyCAoKUtOybqnmfv/+fbNS78d9LmXeX6dDERufiFI+uVHO14NZSERkJ1jV3BFc2o24Oc/g35ndMXjpIdyOjIFPAV8E9J+Pd7o1Y9BNRGRDpLp3zZo1sWXLFuM8qT4u0/Xr13/se6Wdd5EiRRAfH49Vq1ahU6dOaS4bGRmJ8+fPo1ChpFJX+UxnZ2ezzz1z5oxqB57e51LGNSlXANNeqIq3W5Rlsy8iIjvCYk57Fn4D+o0fQXNiJZwBFNJ7oIT2Djo1rYfBzcvA1Uln6RQSEdETkKHEevXqhVq1aqFOnTqYPn06oqKiVPVx8dprr6kAWzo3E/v27cP169dRrVo19Sw9mEuwPmrUKOM633nnHXTs2FFVL5dhwmSoMilZ79mzp3pdOkeTKufy2fny5VO9t0ov6hJ0p9ajOT0ZL3dnPF+dTb+IiOwNA297FB8D7JmFxB1fQRv3AIl6DZYmNMd63wGY170hAvw4NBsRkS174YUXcOvWLYwdO1Z1bCYBtXSKZuhwTUqhpadzA6liLmN5X7hwAR4eHmjfvj0WL15sVmX82rVrKsiWquhSNb1Ro0bYu3ev+t9g2rRpar0yFJn0lC6dts2ePTuHt56IiMj2cBxve3P3AvRLukFz97yaPJhYDpP0fdCudVv0aVgKOi17KycisvVxvG2Vo29/emZsOQcnnRZdahSBbx7z4d+IiMi2z2ss8bYzJyM9ked+DFz13pgU1xO3/TtjepcqKJYvl6WTRkRERGmQDtW+3XkBEdHxqFkiLwNvIiI7w8Db1sU+AA4uQHSNfpi29RLm77yIUvq38MDVFyO61kLXGkXYOQsREZGV23Phjgq6fTxcVeBNRET2hYG3rdLrgVNrgQ0fAuHXsGDbOcwLb61eKl+lNsZ3rIQCnhw7lYiIyBasPxGsnttU8mWzMCIiO8TA2xaF/gv8OQq4uENNXtP74FBkfvjmccUnnSujVcWkznWIiIjI+iUk6rHxZNK47G0DOSY6EZE9YuBtS6LDgG2fA/vmAfoERMMFc+OfxZz459C1bhlMaxeAPG4ycBgRERHZigOX7uJOVKwaSqyef35LJ4eIiLIBA29b8uvbwMk16t/1CbXxSfwrcM5fEt93qcwTNRERkY1af+Kmem5ZwRfOuv+GgSMiIvvBwNsW2nJrNNDr9djg0xulcRATY1/G36iK15v44+0WZeHmrLN0KomIiOgJyTne3VmHdqxmTkRktxh4W6uo28CWCYCTO67UHY8xa/7B7qAoAJ8jsIgX1nWpop6JiIjItk3oFIjR7SrASaexdFKIiCibMPC2NgnxwMHvgK2fqjbdiRodXttTGZfi8sHVSYvhrcqhf6NScGJVNCIiIrvh7sLaa0RE9oyBtzW5tAv4YxQQelJNXtD5490Hr+KSPh/q+efD512qoKRPbkunkoiIiLKoivnlOw94bicicgAMvK1BZCiwfjRwYpWafOiUB59Fd8OP0c2R280Fn7evgBdqF4NGwypoRERE9uLf4Ai0/2YnqhT1wto3G0Kr5XmeiMheZVvXmZcuXUK/fv1QqlQpuLu7o3Tp0hg3bhxiY2Oz6yNtl0YLBG2GXqPFOud2qB/5FRbHt0SrSoWweUQTvFinOINuIiIiO7P+ZFJv5r553Bh0ExHZuWwr8T59+jQSExMxb948lClTBidOnMCAAQMQFRWFyZMnZ9fH2o5rB4EiNVWP5RE6L/zq9x5+PAOc1JeEj4cr5nSqhHaVC1k6lURERJRN1p8IVs9tK/kxj4mI7Fy2Bd5t27ZVDwN/f3+cOXMGc+bMSTPwjomJUQ+D8PBw2J0754EN7wNn1wM9f8Jf+hr4YM0JBIeVVC/3qFUUH7SvCK9czpZOKREREWWT87cicTYkEk5ajRq/m4iI7FuOtvEOCwtDvnz50nx90qRJmDBhAuxSbBSwcwrw9wwgIRZ6rRPWbN6BEVcT1cvF8+XCpC6V0bCMj6VTSkRERNls/YmkauYNyvjwZjsRkQPIscA7KCgIM2bMeGw18zFjxmDEiBFmJd7FihWDTdPrgZNrgI0fAuHX1ayQAg0w8HYPHLlaENKPSv9n/DG8ZTkOJUJERORggTermRMROYZMB96jR4/GF1988dhl/v33XwQEBBinr1+/rqqdd+/eXbXzTourq6t62JVfhgJHFqt/4/MUwyyXfph2taz0qIYAP0982a0KqhT1tnQqiYiIKIdcu/cAx6+HSTcvaF2J1cyJiBxBpgPvkSNHonfv3o9dRtpzG9y4cQPNmjVDgwYN8O2338LhVOgI/fEVOFq8N/oGNcS9WB1cdFq83bIsXm/sD2ddtnUsT0RERFZIOlH932u1cOZmuPqfiIjsX6YD7wIFCqhHRkhJtwTdNWvWxMKFC6HV2nmQmZgIHP1R9VSO6q+oWee8GuAzr/nYeipp22uXzItJXaqgTEEPCyeWiIiILMHNWYdWFX3Vg4iIHEO2tfGWoLtp06YoUaKEatd969Yt42t+fnY4bMb1Q8Af7yY9u3oh1r8VZh8Iw6ytQYhL0MLD1QnvtQvAy3WKc6xOIiIiIiIiB5JtgfemTZtUh2ryKFq0qNlreulwzF5E3gK2TACOLJEtA1w8ca3KELz+3XGcCk0aGq1FQEF83DkQhb3dLZ1aIiIisqDf/wnGv8Hh6FStMMr6enJfEBE5iGwLvKUdeHptwW1aQjxwYD6w9TMgJkzNigt8Ad9oX8bMXZHQ62OQP7cLxj1XCR2rFIJGqp8TERGRQ1u2/wp2Bd2Gh5sTA28iIgeSo+N425U754ANYwB9IuBXBUcqf4ghO51x/X6kerlL9SL46NmKyJvbxdIpJSIiIitwLyoWey7cUf9zGDEiIsfCwDszYiIB10edohWsADzzDqJcC2Ls1RpY9auMxxmPIt7u+PT5QDQtXzB79hgRERHZpE3/hiAhUa+GEy3pk9vSySEiohxk592MZ5H4GGDHZGBqRSD0X2M79V/y90Hjv0pi1dGbqiPzPg1LYuPwxgy6iYiIKIUNJ+QmPdAusBBzh4jIwTDwTs/ZDcCsusBfHye15T6yBMFhD9H/+4N4a9kR3ImKRdmCHlg5sAHGdayE3K6sREBERNlv1qxZKFmyJNzc3FC3bl3s378/zWXj4uIwceJElC5dWi1ftWpVrF+/3myZSZMmoXbt2vD09ETBggXRuXNnnDlzxmwZGa1E+iwxfQwcODDbttGeRETHYee52+r/toF2OLoLERE9FgPvtNw5D/zYA1jaA7h3EfDwQ+Lz32JxngFoNXUHtpwOhbNOg2Ety+K3txqhZom8j89pIiKiLLJ8+XKMGDEC48aNw+HDh1Ug3aZNG4SGhqa6/Icffoh58+ZhxowZOHXqlAqWn3/+eRw5csS4zPbt2zF48GDs3btXjUwiwXrr1q0RFRVltq4BAwYgODjY+Pjyyy+5XzNg65lbiE1IhL9PbpTzfdRsjYiIHAaLZ1Ozcwqw7XMgIRbQOgP1BuFCpcEY/etF7L90Ui1Svbg3vuhaBeU4FAgREeWwqVOnqgC4T58+anru3Ln4/fffsWDBAowePTrF8osXL8YHH3yA9u3bq+lBgwZh8+bNmDJlCpYskeEwkaIEfNGiRark+9ChQ2jcuLFxfq5cueDnxxLbzAp7GAfvXM5oE+jHkU6IiBwQA+/U6FyTgu7SzRHX+nN8e0qHr+ccQWx8InK56PBum/J4rX5J6LQcIoyIiHJWbGysCobHjBljnKfVatGyZUvs2bMn1ffExMSoKuam3N3dsWvXrjQ/JywsaajMfPnymc3/8ccfVbAuwXfHjh3x0UcfqWA8rc+Vh0F4eDgc1av1SuDF2sUQHZdg6aQQEZEFMPAWISeB2AdAsdpJuVL3DaBAefzjVgvv/XQC/wYnXSg0LlcAnz0fiKJ5U7/AICIiym63b99GQkICfH19zebL9OnTp1N9j1RDl1JyKbmWdt5btmzB6tWr1XpSk5iYiGHDhqFhw4YIDAw0zn/ppZdQokQJFC5cGP/88w/ee+891Q5c1pUaaTc+YcKEp9pee+Ks06oHERE5HvsPvLdOArQ6oMmolK9tngBc2A4EHwXylQIG7QGcXPAwQYupZ4vgu11/I1EPVTVs7LMV8Xz1IqweRkRENufrr79WVdMDAgLUeUyCb6mmLlXTUyNtvU+cOJGiRPz11183/l+5cmUUKlQILVq0wPnz59U6k5NSeWmLblriXaxYsSzdNltw9e4DFM3rzmsIIiIHZv+BtwTdWz9N+t8QfCcmAstfBs788d9yMi53bCR2X0rEmNXHceXuAzX7uaqFMbZjRfh4uFoi9URERGZ8fHyg0+kQEhJiNl+m02p7XaBAAaxduxbR0dG4c+eOKrGWtuD+/v4plh0yZAh+++037NixA0WLFn1s7ktv6iIoKCjVwNvV1VU9HJk0U2v/zU7kcXPGT6/XQ7F8rDVHROSI7D/wNgTbhuC7dIukoDsiOGnapxzQ7kuEFWqET/84hZ8PXlOzC3m54ZPOgWhRwbwqHxERkSW5uLigZs2aqrq4DPllqBou0xI0P4608y5SpIjqsXzVqlXo0aOH8TW9Xo+hQ4dizZo12LZtG0qVKpVuWo4ePaqepeSbUvf3+duIiI6Hq5MOhb3dmU1ERA7K/gNv0WQUEvV6aCX4fhSA63Uu0LQYp9pz/3nqNsZO245bEUkdwLxSrzjeaxsATzdnCyeciIgoJam+3atXL9SqVQt16tTB9OnT1bBfhl7OX3vtNRVgSxtrsW/fPly/fh3VqlVTz+PHj1fB+qhRo8yqly9duhTr1q1TY3nfvHlTzffy8lIdsUl1cnldekbPnz+/auM9fPhw1W68SpUq3E1p2HAyKR/bVPJlp6xERA7MIQLv9SeCMWFPLWzTO8FVE48EvQbP6ebgVac62Lr0GDacTKqu518gtxoirHZJ8x5ciYiIrMkLL7yAW7duYezYsSpAloBahgMzdLh25coV1dO5gVQxl7G8L1y4AA8PDxU8yxBj3t7exmXmzJmjnps2bWr2WQsXLkTv3r1VSbsMQWYI8qWtdteuXdV66T/TNp1VAfZbLcoiIVGPjY+uMdoFFsI3W86pecNblWOWERE5GCdHCLoHLTmMIbrVcHWOR6zeCS6aeDSP+hOjVydV+XLSajCwSWkMaV4Gbs46SyeZiIgoXVKtPK2q5VJV3FSTJk1w6tSpx65Pqpo/jgTa27dv555JhwTdUzedVf/XKZUPd6Ji4eXujAOX7uLrLecwgkE3EZFDsuvAW+4qT/j1lAq6RzqvxJS4bpiR0AVDH02LueiK1YMaonJRL0snl4iIiGyclHQLCb6rF0uqUVAkr7sx6Da8TkREjsWuA+/9F++iW+RSs6BbGJ5V8B0HRMYk9cpKRERE9LQkuJYaBNM2n1PTp26EM+gmInJw/zUAs0OhEdHQaRLNgm4DmZb58rosR0RERJRVhjYvq5qyCWddUptvIiJyXHZd4l3Q0w1vx3dL83VDML7M0y0HU0VERET2bubWIMQn6uGi0yI2IVF1rMbgm4jIcdl1ibd0aiLjcSfdb05J5svrshwRERFRVpAgW9p4S5vus5+2U88yLfOJiMgxae29Z9FxHSuq/5MH34ZpeV2WIyIiIsrKoNtQwi3PDL6JiBybXQfeom1gIcx5pQb8vMyrk8u0zJfXiYiIiLJqRJXUei83BN/yOhEROR6NPr2BOy0oPDwcXl5eCAsLQ548eZ5qXXKik17OpSM1afst1ctZ0k1ERLZ6XrNFjr79RETkuOc1u+5czZQE2fVL57d0MoiIiIiIiMjB2H1VcyIiIiIiIiJLYuBNRERERERElI0YeBMRERERERFlIwbeRERERERERNmIgTcRERERERFRNrLqXs0NI51JN+1ERES2znA+s+KRPLMVz+tEROSo53WrDrwjIiLUc7FixSydFCIioiw9v8m4n46G53UiInLU87pGb8W33RMTE3Hjxg14enpCo9FkyR0JCeKvXr2a7gDn1ozbYT24L6wL94f14L5InZxy5eRcuHBhaLWO19orq8/r1s5evgeWwvxj3vHYsz2O9r3VZ+K8btUl3pL4okWLZvl65SCwhwOB22E9uC+sC/eH9eC+SMkRS7qz+7xu7ezle2ApzD/mHY892+NI31uvDJ7XHe92OxEREREREVEOYuBNRERERERElI0cKvB2dXXFuHHj1LMt43ZYD+4L68L9YT24L4js53tgKcw/5h2PPdvD762Ndq5GREREREREZOscqsSbiIiIiIiIKKcx8CYiIiIiIiLKRgy8iYiIiIiIiLIRA28iIiIiIiKibGR3gfesWbNQsmRJuLm5oW7duti/f/9jl1+xYgUCAgLU8pUrV8Yff/wBW9uORYsWQaPRmD3kfZa0Y8cOdOzYEYULF1bpWbt2bbrv2bZtG2rUqKF6QyxTpozaLkvL7HbINiTfF/K4efMmLGXSpEmoXbs2PD09UbBgQXTu3BlnzpxJ933W9t14ku2wxu/GnDlzUKVKFeTJk0c96tevjz///NOm9kVmt8Ea90NqPv/8c5W2YcOG2dT+IPu4HqGnu4agpzvn05Odn+npz6mOxK4C7+XLl2PEiBFq6I7Dhw+jatWqaNOmDUJDQ1Nd/u+//0bPnj3Rr18/HDlyRP04yePEiROwpe0Q8gMRHBxsfFy+fBmWFBUVpdItFx4ZcfHiRXTo0AHNmjXD0aNH1Ze0f//+2LBhA2xpOwzkJGe6P+TkZynbt2/H4MGDsXfvXmzatAlxcXFo3bq12ra0WON340m2wxq/G0WLFlUno0OHDuHgwYNo3rw5OnXqhJMnT9rMvsjsNljjfkjuwIEDmDdvnrroehxr3B9kfZ7kPE5Pf+6lJz9X0pOd2+jpzqkOR29H6tSpox88eLBxOiEhQV+4cGH9pEmTUl2+R48e+g4dOpjNq1u3rv6NN97Q29J2LFy4UO/l5aW3VnKYrVmz5rHLjBo1Sl+pUiWzeS+88IK+TZs2elvajq1bt6rl7t27p7dWoaGhKo3bt29Pcxlr/W5kdjus/bthkDdvXv38+fNtdl+ktw3Wvh8iIiL0ZcuW1W/atEnfpEkT/dtvv53msrayP0hvU+dxerpzLz3duZKe7NxGT39OdTR2U+IdGxur7lC1bNnSOE+r1arpPXv2pPoemW+6vJA70mktb63bISIjI1GiRAkUK1bMJu/OWeO+eBrVqlVDoUKF0KpVK+zevRvWJCwsTD3ny5fPpvdHRrbD2r8bCQkJ+Omnn1RJhFRps8V9kZFtsPb9IKVDUuMmeT7b4v4gy3vS8ziRJc+V9GTnNnq6c6qjcYKduH37tvqS+Pr6ms2X6dOnT6f6Hml3m9rylmyP+yTbUb58eSxYsEBV55Af2MmTJ6NBgwbqwlaqzdiCtPZFeHg4Hj58CHd3d9gCCbbnzp2LWrVqISYmBvPnz0fTpk2xb98+1X7d0hITE1U1/oYNGyIwMDDN5azxu/Ek22Gt343jx4+rE3l0dDQ8PDywZs0aVKxY0ab2RWa2wVr3g5ALK6kKLNXiMsJa9wdZjyc5jxNZ8lxJT3Zuo6c/pzoauwm8HZn8QJjejZML2goVKqi2FR9//LFF0+ZoJMCQh+m+OH/+PKZNm4bFixfDGu5CSlvUXbt2wZZldDus9bshx4j0ZSBB6MqVK9GrVy/VLs+WTu6Z2QZr3Q9Xr17F22+/rdpBWmNnb0RET8Nezvk5yR7Oz5bCc6oDBd4+Pj7Q6XQICQkxmy/Tfn5+qb5H5mdmeWvdjuT+396dhkTVhQEcP+6V9ibtVlhq2EaLGZbVh8IiMi2L9oggKCjavlhB0Z4lWSGpgbRIEWQfzFBBpSwEyfY922wjKqIoaIEWPC/PeXFep9S6o9PM1P8H08xd55x75vZ45p77jJ+fn4qKilIPHjxQnqKhtpCETJ5ytbshMTExbhH0lixZogoLC0222J9dZXTHc8ORerjrueHv728y94vo6GjzzXB6errpiHpKW1ipg7u2gwwHlmRXdUejyJVK+WxlZGSYUSvy/7EntAfcR3PEccCVsfJv1pTY9rdzJKb+bbz/pBNFTpBTp07ZDbGR6YbuzZD5ddcXcuXDlfdyOFKP78mHXIbKyLBnT+GObdFc5JtTV7aF5KaRACzDpcrKylRYWJhHtocj9fCUc0POcQlIntIWVuvgru0QFxdnyiHnaO1DbhOZM2eOeV3fHwie0h5QHh3HAVfGSjgW2/52jsTUv47+gxw9elQHBATonJwcffv2bb1w4UIdHBysX758aZbPnTtXr1692rZ+RUWF9vX11WlpabqqqkqvX79e+/n56Rs3bnhUPTZu3KhLSkp0dXW1vnTpkp45c6Zu0aKFvnXrlkszGl65csU85GO2a9cu8/rJkydmuZRf6lHr4cOHulWrVjo5Odm0RWZmpvbx8dHFxcXalazWY/fu3To/P1/fv3/ffI4kk6O3t7c+efKky+qwaNEik1H6zJkz+sWLF7bHp0+fbOt4wrnhSD3c8dyQ8kl22UePHunr16+baS8vL11aWuoxbWG1Du7YDg35PgOrJ7QH3M/P4jiaFnvRtFgJx2IbrCOrub0/quMt9uzZo0NDQ7W/v7/5OY/Kykq7xp83b57d+seOHdORkZFmffk5q6KiIu1p9VixYoVt3U6dOun4+Hh9+fJl7Uq1P6v1/aO23PIs9fh+m0GDBpl6hIeHm58gcjWr9UhNTdURERGmU9G2bVs9atQoXVZW5vKfYqnvUff4esK54Ug93PHcmD9/vu7evbspU4cOHXRcXJxdUPeEtrBaB3dsh1/9I8ET2gPuqbE4jqbFXjQtVsKx2Abr6Hjb85J/XH3VHQAAAACAP9Ufc483AAAAAADuiI43AAAAAABORMcbAAAAAAAnouMNAAAAAIAT0fEGAAAAAMCJ6HgDAAAAAOBEdLwBAAAAAHAiOt4AAAAAADgRHW8AjfLy8lL5+flNOko5OTkqODiYIw0AgIsR1wHXoOMN/CYvX75Uy5cvVz179lQtWrRQnTp1UiNGjFB79+5Vnz59ctt2ePHihRo/fryriwEAgFshrgOwwtfS2gAc8vDhQ9PJlqu+KSkpqn///iogIEDduHFDZWdnq65du6qJEyfWu+3Xr1+Vn5+fy458586dXfbeAAC4I+I6AKu44g38BosXL1a+vr7q4sWLavr06apPnz4qPDxcTZo0SRUVFanExES7IWByFVw64oGBgWrr1q1mvsyLiIhQ/v7+qlevXurw4cO2bR4/fmy2u3r1qm3eu3fvzLwzZ86YaXmWaXm/AQMGmKvuw4YNUzdv3vzlIWm175OXl6dGjx6tWrVqpQYOHKjOnj37w9Dy0NBQs3zy5MnqzZs3P+z3xIkTavDgwaYcciw2btyovn37ZpZt2rRJdenSxW67CRMmmPesqamxfPwBAGhOxHXiOmCZBuBUr1+/1l5eXnrbtm2/tL6clh07dtQHDhzQ1dXV+smTJzovL0/7+fnpzMxMfffuXb1z507t4+Ojy8rKzDaPHj0y2125csW2n7dv35p5p0+fNtPyLNN9+vTRpaWl+vr16zohIUH36NFDf/nypdHyHD9+3O59evfurQsLC01Zpk6dqrt3766/fv1q1qmsrNTe3t46NTXVLE9PT9fBwcG6TZs2tn2Wl5frf/75R+fk5Jg6SnmkHBs2bDDLv337pmNjY3VSUpKZzsjIMPuQYwEAgCsR14nrgCPoeANOJh1R6axK57mudu3a6cDAQPNYuXLl/yelUnrFihV26w4fPlwvWLDAbt60adN0fHy85Y730aNHbeu8efNGt2zZUufm5lrqeO/bt8+2/NatW2ZeVVWVmZ41a5atXLVmzJhh1/GOi4vTKSkpduscPnxYh4SE2KalQ966dWu9atUqU8YjR440WEYAAH4X4jpxHXAEQ80BFzl//rwZGt6vXz/1+fNnu2VDhgyxm66qqjL3iNcl0zLfqtjYWNvrtm3bmmHrVvcjQ9VrhYSEmOdXr17Zyjp06NAG31Ncu3bNDCcPCgqyPRYsWGASudUmmpPh52lpaSo1NdUMu589e7blugIA8LsQ14nrQGNIrgY4mWQxl/ui7969azdfOpaiZcuWP2wj93Zb4e3933do/12g/j8pm7PUTfYmdRNW7r3+8OGDuad7ypQpPyyTe75rlZeXKx8fH3Nvudz/LffJAwDgSsT1HxHXgZ/jijfgZO3atVNjx45VGRkZ6uPHjw7tQ5KxVVRU2M2T6b59+5rXHTp0MM9yxbhW3URrdVVWVtpev337Vt27d8/sv7nIvs6dO9fgewpJqiZfRMgfL98/ar9EyM3NNUncJCnc06dP1ebNm5utjAAAOIq4TlwHHMHlI+A3yMrKMkPDZQj5hg0bzFBt6WBeuHBB3blzR0VHRze6fXJyssmGHhUVpcaMGaMKCgpMp/TkyZO2q+aSoXz79u0qLCzMDPteu3ZtvfuSId7yR4P8jviaNWtU+/btVVJSUrPVddmyZaauMkxcsraXlJSo4uJiu3XWrVunEhISTObzqVOnmmMhw88lw/qWLVvUs2fP1KJFi8ww85EjR6qDBw+a9eX3xKWeAAC4EnGduA5Y5tCd4QAse/78uV6yZIkOCwszGcqDgoJ0TEyM3rFjh/748WO9yczqysrK0uHh4WbbyMhIfejQIbvlt2/fNpnAJRHZoEGDTKbw+pKrFRQU6H79+ml/f3/z/teuXWu03PUlV2ssiZvYv3+/7tatmylLYmKiTktLs0uuJoqLi03SOFlHMpxLWbKzs3VNTY1JvjZu3DjzutbSpUt1RESEfv/+vYWjDgCAcxDXieuAFV7yj/XuOgBPI0O25XewZXh5cHCwq4sDAACagLgOeBbu8QYAAAAAwInoeAMAAAAA4EQMNQcAAAAAwIm44g0AAAAAgBPR8QYAAAAAwInoeAMAAAAA4ER0vAEAAAAAcCI63gAAAAAAOBEdbwAAAAAAnIiONwAAAAAATkTHGwAAAAAA5Tz/ApTFAyFTUJB3AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1000x400 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "post_mu_means = idata.posterior[\"mu\"].mean(dim=(\"chain\", \"draw\")).values\n",
+    "post_sigma_means = idata.posterior[\"sigma\"].mean(dim=(\"chain\", \"draw\")).values\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(10, 4))\n",
+    "\n",
+    "# Plot for mu\n",
+    "axes[0].plot(mu_true, \"o-\", label=\"True mu\")\n",
+    "axes[0].plot(post_mu_means, \"x--\", label=\"Posterior mean mu\")\n",
+    "axes[0].set_title(\"Group means\")\n",
+    "axes[0].set_xlabel(\"Group index\")\n",
+    "axes[0].legend()\n",
+    "\n",
+    "# Plot for sigma\n",
+    "axes[1].hlines(sigma_true, xmin=-0.5, xmax=num_groups - 0.5, label=\"True sigma\")\n",
+    "axes[1].plot(post_sigma_means, \"x--\", label=\"Posterior mean sigma\")\n",
+    "axes[1].set_title(\"Group standard deviations\")\n",
+    "axes[1].set_xlabel(\"Group index\")\n",
+    "axes[1].legend()\n",
+    "\n",
+    "fig.suptitle(\"Vector variables: posterior vs true values\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ebdcb75",
+   "metadata": {},
+   "source": [
+    "## 6. Takeaways\n",
+    "\n",
+    "- You can represent many similar parameters at once by using **vector-valued\n",
+    "  random variables** with a `shape` argument.  \n",
+    "- Use integer labels (like `data_labels`) to index into these vectors and\n",
+    "  connect each observation to the right group parameter.  \n",
+    "- This pattern generalizes to more complex models, including hierarchical\n",
+    "  models where the vector parameters themselves have hyperpriors.\n",
+    "\n",
+    "You can now adapt this pattern to your own models whenever you have many\n",
+    "groups (or categories) that share the same likelihood form but different\n",
+    "parameters."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4862024f",
+   "metadata": {},
+   "source": [
+    "## Watermark\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "382a41d8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The watermark extension is already loaded. To reload it, use:\n",
+      "  %reload_ext watermark\n",
+      "Last updated: Sat Nov 22 2025\n",
+      "\n",
+      "Python implementation: CPython\n",
+      "Python version       : 3.13.9\n",
+      "IPython version      : 9.7.0\n",
+      "\n",
+      "pytensor: 2.35.1\n",
+      "xarray  : 2025.11.0\n",
+      "\n",
+      "matplotlib: 3.10.7\n",
+      "pymc      : 5.26.1\n",
+      "arviz     : 0.22.0\n",
+      "numpy     : 2.3.5\n",
+      "debugpy   : 1.8.17\n",
+      "ipykernel : 7.1.0\n",
+      "\n",
+      "Watermark: 2.5.0\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext watermark\n",
+    "%watermark -n -u -v -iv -w -p pytensor,xarray"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/howto/vector_variables.myst.md
+++ b/examples/howto/vector_variables.myst.md
@@ -1,0 +1,249 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+kernelspec:
+  display_name: venv
+  language: python
+  name: python3
+---
+
+# Demonstrating Vector Variables in PyMC
+
+This tutorial shows how to work with **vector-valued random variables** in PyMC,
+using a simple example with several groups of data that share a common
+structure but have different means (and optionally different standard
+deviations).
+
+We will:
+
+1. Simulate data from multiple groups.  
+2. Build a PyMC model with vector parameters `mu` (means) and `sigma`.  
+3. Use indexing to connect each observation to the right group parameter.  
+4. Sample from the posterior and inspect the results.
+
+
++++
+
+## 1. Setup
+
+We start by importing the libraries we need and fixing a random seed for
+reproducibility.
+
+```{code-cell} ipython3
+import arviz as az
+import numpy as np
+import pymc as pm
+
+RANDOM_SEED = 123
+rng = np.random.default_rng(RANDOM_SEED)
+```
+
+```{code-cell} ipython3
+import os
+
+# Configure PyTensor to use g++ compiler if available, otherwise suppress warning
+import pytensor
+
+# Try to find g++ compiler
+gxx_paths = [
+    r"C:\Users\mrcle\miniconda3\Library\bin\x86_64-w64-mingw32-g++.exe",
+    "g++",  # Try system g++ if in PATH
+]
+
+gxx_found = None
+for path in gxx_paths:
+    if path == "g++":
+        # Check if g++ is in PATH
+        import shutil
+
+        if shutil.which("g++"):
+            gxx_found = "g++"
+            break
+    elif os.path.exists(path):
+        gxx_found = path
+        break
+
+if gxx_found:
+    pytensor.config.cxx = gxx_found
+    print(f"PyTensor configured to use: {gxx_found}")
+else:
+    # Suppress warning if compiler not found
+    pytensor.config.cxx = ""
+    print(
+        "g++ compiler not found. PyTensor will use Python fallback (slower but works fine for examples)."
+    )
+```
+
+## 2. Simulate grouped data
+
+We create:
+
+- `num_groups`: how many groups we have.  
+- `group_size`: how many observations per group.  
+- `sigma_true`: shared standard deviation of the observation noise.  
+- `mu_true`: a vector of true group means (used only to generate fake data).
+
+We then build:
+
+- `data`: stacked observations from all groups.  
+- `data_labels`: an integer label (0, 1, ..., `num_groups-1`) telling us
+  which group each observation belongs to.
+
+```{code-cell} ipython3
+num_groups = 5
+group_size = 200
+sigma_true = 1.0
+
+# True means for each group (just for simulation, not known to the model)
+mu_true = rng.normal(loc=np.linspace(-2, 2, num_groups), scale=0.5, size=num_groups)
+
+# Simulate data: for each group, draw `group_size` points
+data_per_group = [rng.normal(loc=mu, scale=sigma_true, size=group_size) for mu in mu_true]
+data = np.concatenate(data_per_group)
+
+# Integer labels telling which group each observation belongs to
+data_labels = np.concatenate(
+    [np.full(group_size, group_id) for group_id in range(num_groups)]
+).astype(int)
+
+data[:10], data_labels[:10]
+```
+
+`data` is a 1D array of length `num_groups * group_size`.
+
+`data_labels` is a 1D integer array of the same length, where each element is
+the group index (from 0 to `num_groups - 1`) for the corresponding observation.
+
+---
+
++++
+
+## 3. Building the PyMC model with vector variables
+
+Key idea: instead of defining separate scalar parameters for each group, we
+define *vector-valued* parameters:
+
+- `mu`: a length-`num_groups` vector of group means.  
+- `sigma`: a length-`num_groups` vector of group standard deviations
+  (or we could use a single shared `sigma` if we prefer).
+
+Then we use **indexing** with `data_labels` to pick the right parameter for
+each observation.
+
+```{code-cell} ipython3
+with pm.Model() as model:
+    # Vector of group means
+    mu = pm.Normal("mu", mu=0.0, sigma=10.0, shape=num_groups)
+
+    # Vector of group standard deviations (half-normal prior)
+    sigma = pm.HalfNormal("sigma", sigma=2.0, shape=num_groups)
+
+    # The likelihood: for each observation i,
+    #   data[i] ~ Normal(mu[data_labels[i]], sigma[data_labels[i]])
+    likelihood = pm.Normal(
+        "y",
+        mu=mu[data_labels],
+        sigma=sigma[data_labels],
+        observed=data,
+    )
+
+model
+```
+
+Notes:
+
+- `mu[data_labels]` creates a 1D array where each element is the mean
+  corresponding to the group of that observation.  
+- Similarly for `sigma[data_labels]`.  
+- This is the crucial **vectorization trick** that avoids explicit Python loops.
+
+---
+
++++
+
+## 4. Sampling from the posterior
+
+Now we run MCMC to obtain samples from the posterior distribution of the
+parameters.
+
+```{code-cell} ipython3
+with model:
+    idata = pm.sample(
+        draws=300,
+        tune=300,
+        chains=1,
+        cores=1,
+        target_accept=0.9,
+        random_seed=RANDOM_SEED,
+    )
+```
+
+## 5. Inspecting the results
+
+We compare the posterior means of `mu` and `sigma` to the true values used to
+simulate the data.
+
+```{code-cell} ipython3
+print("Posterior summary for mu:")
+display(az.summary(idata, var_names=["mu"]))
+
+print("\nPosterior summary for sigma:")
+display(az.summary(idata, var_names=["sigma"]))
+```
+
+### Optional: visual comparison
+
+If `matplotlib` is available, we can visualize the posterior mean of each
+parameter against the true (simulated) value.
+
+```{code-cell} ipython3
+import matplotlib.pyplot as plt
+
+post_mu_means = idata.posterior["mu"].mean(dim=("chain", "draw")).values
+post_sigma_means = idata.posterior["sigma"].mean(dim=("chain", "draw")).values
+
+fig, axes = plt.subplots(1, 2, figsize=(10, 4))
+
+# Plot for mu
+axes[0].plot(mu_true, "o-", label="True mu")
+axes[0].plot(post_mu_means, "x--", label="Posterior mean mu")
+axes[0].set_title("Group means")
+axes[0].set_xlabel("Group index")
+axes[0].legend()
+
+# Plot for sigma
+axes[1].hlines(sigma_true, xmin=-0.5, xmax=num_groups - 0.5, label="True sigma")
+axes[1].plot(post_sigma_means, "x--", label="Posterior mean sigma")
+axes[1].set_title("Group standard deviations")
+axes[1].set_xlabel("Group index")
+axes[1].legend()
+
+fig.suptitle("Vector variables: posterior vs true values")
+plt.tight_layout()
+plt.show()
+```
+
+## 6. Takeaways
+
+- You can represent many similar parameters at once by using **vector-valued
+  random variables** with a `shape` argument.  
+- Use integer labels (like `data_labels`) to index into these vectors and
+  connect each observation to the right group parameter.  
+- This pattern generalizes to more complex models, including hierarchical
+  models where the vector parameters themselves have hyperpriors.
+
+You can now adapt this pattern to your own models whenever you have many
+groups (or categories) that share the same likelihood form but different
+parameters.
+
++++
+
+## Watermark
+
+```{code-cell} ipython3
+%load_ext watermark
+%watermark -n -u -v -iv -w -p pytensor,xarray
+```


### PR DESCRIPTION
This PR adds a new tutorial notebook demonstrating how to work with
vector-valued (shaped) random variables in PyMC.  
It addresses feature request **#4007**.

---

The notebook introduces a beginner-friendly example showing how to:

- define vector-valued `mu` and `sigma` parameters using `shape=`
- generate grouped data and integer labels
- use indexing (`mu[data_labels]`, `sigma[data_labels]`) to map observations
  to the correct group parameters
- fit the model using `pm.sample`
- visualize posterior means vs. true simulated values

This notebook provides a simple, clear demonstration intended for new users.

---

Notebook location

`examples/howto/vector_variables.ipynb`

---

Checklist

- [x] Notebook follows PyMC’s Jupyter style guide  
      https://docs.pymc.io/en/latest/contributing/jupyter_style.html  
- [x] Linked to the relevant issue (#4007)  
- [x] Confirmed notebook is not excluded by pre-commit config  
      https://github.com/pymc-devs/pymc-examples/blob/main/.pre-commit-config.yaml  

---
Any feedback and notices for further adjustments would be greatly appriciated as this is my first ever pr.

