### PR TITLE
Update heteroskedastic Gaussian process notebook

### DIFF
--- a/examples/gaussian_processes/GP-Heteroskedastic.ipynb
+++ b/examples/gaussian_processes/GP-Heteroskedastic.ipynb
@@ -241,7 +241,7 @@
     "    ax.plot(Xnew, ynew, \"--k\", label=\"Mean Function\")\n",
     "    ax.plot(X_obs, y_obs_, \"C1.\", label=\"Observations\")\n",
     "    ax.set_title(\"Aggregate Behavior\")\n",
-    "    ax.legend(loc=\"upper left\")\n"
+    "    ax.legend(loc=\"upper left\")"
    ]
   },
   {
@@ -381,7 +381,7 @@
     "noisy_samples = ppc_hm[\"noisy_pred_hm\"].values\n",
     "plot_mean(axs[0], mu_samples, sample_axis=1)\n",
     "plot_var(axs[1], noisy_samples.var(axis=1))\n",
-    "plot_total(axs[2], noisy_samples, sample_axis=1)\n"
+    "plot_total(axs[2], noisy_samples, sample_axis=1)"
    ]
   },
   {
@@ -521,13 +521,11 @@
    ],
    "source": [
     "_, axs = plt.subplots(1, 3, figsize=(18, 4))\n",
-    "mu_samples = (\n",
-    "    samples_wt.posterior_predictive.stack(sample=(\"chain\", \"draw\"))[\"mu_pred_wt\"].values\n",
-    ")\n",
+    "mu_samples = samples_wt.posterior_predictive.stack(sample=(\"chain\", \"draw\"))[\"mu_pred_wt\"].values\n",
     "plot_mean(axs[0], mu_samples, sample_axis=1)\n",
     "axs[0].errorbar(X_, y, y_err, ls=\"none\", color=\"C1\", label=\"STDEV\")\n",
     "plot_var(axs[1], mu_samples.var(axis=1))\n",
-    "plot_total(axs[2], mu_samples, sample_axis=1)\n"
+    "plot_total(axs[2], mu_samples, sample_axis=1)"
    ]
   },
   {
@@ -685,7 +683,7 @@
     "σ_samples = np.exp(ppc_ht[\"lg_σ_pred_ht\"].values)\n",
     "plot_mean(axs[0], μ_samples, sample_axis=1)\n",
     "plot_var(axs[1], σ_samples**2, sample_axis=1)\n",
-    "plot_total(axs[2], μ_samples, σ_samples**2, sample_axis=1)\n"
+    "plot_total(axs[2], μ_samples, σ_samples**2, sample_axis=1)"
    ]
   },
   {
@@ -884,7 +882,7 @@
     "plot_var(axs[1], σ_samples**2, sample_axis=1)\n",
     "plot_inducing_points(axs[1])\n",
     "plot_total(axs[2], μ_samples, σ_samples**2, sample_axis=1)\n",
-    "plot_inducing_points(axs[2])\n"
+    "plot_inducing_points(axs[2])"
    ]
   },
   {
@@ -1054,7 +1052,7 @@
     "axs[1].legend(loc=\"upper left\")\n",
     "plot_inducing_points(axs[1])\n",
     "plot_total(axs[2], μ_samples, σ_samples**2, sample_axis=1)\n",
-    "plot_inducing_points(axs[2])\n"
+    "plot_inducing_points(axs[2])"
    ]
   },
   {
@@ -1138,7 +1136,7 @@
     "diag_kappa = I * kappa[:, None, :]\n",
     "\n",
     "B = WW_T + diag_kappa\n",
-    "B.mean(axis=2)\n"
+    "B.mean(axis=2)"
    ]
   },
   {
@@ -1158,13 +1156,13 @@
     }
    ],
    "source": [
-    "sd = np.sqrt(np.diagonal(B, axis1=0, axis2=1)) \n",
+    "sd = np.sqrt(np.diagonal(B, axis1=0, axis2=1))\n",
     "outer_sd = np.einsum(\"sd,se->des\", sd, sd)\n",
     "correlation = B / outer_sd\n",
     "\n",
     "print(f\"2.5%ile correlation: {np.percentile(correlation,2.5,axis=2)[0,1]:0.3f}\")\n",
     "print(f\"Median correlation: {np.percentile(correlation,50,axis=2)[0,1]:0.3f}\")\n",
-    "print(f\"97.5%ile correlation: {np.percentile(correlation,97.5,axis=2)[0,1]:0.3f}\")\n"
+    "print(f\"97.5%ile correlation: {np.percentile(correlation,97.5,axis=2)[0,1]:0.3f}\")"
    ]
   },
   {
@@ -1251,7 +1249,7 @@
     "plot_inducing_points(axs[2])\n",
     "\n",
     "axs[0].legend().remove()\n",
-    "axs[1].legend().remove()\n"
+    "axs[1].legend().remove()"
    ]
   },
   {
@@ -1735,7 +1733,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "PyMC Examples (pixi)",
+   "display_name": "PyMC Examples",
    "language": "python",
    "name": "pymc-examples"
   },
@@ -1749,7 +1747,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.11"
+   "version": "3.12.12"
   },
   "toc-showtags": false
  },

--- a/examples/gaussian_processes/GP-Heteroskedastic.myst.md
+++ b/examples/gaussian_processes/GP-Heteroskedastic.myst.md
@@ -5,7 +5,7 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: PyMC Examples (pixi)
+  display_name: PyMC Examples
   language: python
   name: pymc-examples
 ---


### PR DESCRIPTION
Updates the notebook on using a Gaussian process with heteroskedastic variance to conform to the style guide and run successfully on v5.

Updates the code to use PyTensor and includes some edits for minor grammar issues.

Relevant issues: #795 #169 #723 

+ [x] Notebook follows style guide https://docs.pymc.io/en/latest/contributing/jupyter_style.html
+ [x] PR description contains a link to the relevant issue:
  * a tracker one for existing notebooks (tracker issues have the "tracker id" label)
  * or a proposal one for new notebooks
+ [x] Check the notebook is not excluded from any pre-commit check: https://github.com/pymc-devs/pymc-examples/blob/main/.pre-commit-config.yaml


### Helpful links
* https://github.com/pymc-devs/pymc-examples/blob/main/CONTRIBUTING.md
