### PR TITLE
Add AGENTS.md with repo structure and build guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md
+
+## Repository structure
+
+- `.ipynb` is the source of truth. A pre-commit jupytext hook auto-generates `.myst.md` from `.ipynb` — edit only the `.ipynb`.
+- Only `.ipynb` files are used by Sphinx; `.myst.md` is excluded via `exclude_patterns` in `examples/conf.py`.
+- `requirements-docs.txt` lists Sphinx/theme dependencies for the ReadTheDocs build only.
+- `sphinxext/thumbnail_extractor.py` is a custom Sphinx extension that extracts thumbnail images from notebook outputs.
+
+## Do not commit
+
+- Agent-generated artifacts, scratch notes, or temporary files (e.g. `.github/pr-summaries/`, draft summaries).
+
+## ReadTheDocs (remote) builds
+
+- `nb_execution_mode = "off"` in `examples/conf.py` — notebooks are never executed during RTD builds. Missing Python packages (pymc, arviz, etc.) cannot cause RTD failures.
+- RTD "Unknown problem" failures with short duration (~140s vs normal ~350s) are transient infrastructure/pip-install failures. Retrigger with an empty commit or from the RTD dashboard before investigating further.


### PR DESCRIPTION
## Summary

- Adds an `AGENTS.md` file documenting repo conventions for AI coding agents
- Covers notebook file pairing (`.ipynb` source of truth, `.myst.md` auto-generated)
- Documents that RTD builds don't execute notebooks, so missing Python packages can't cause RTD failures
- Notes that RTD "Unknown problem" failures with short duration are transient and should be retriggered
- Reminds agents not to commit scratch artifacts

## Test plan

- [x] Pre-commit hooks pass
- [ ] Verify file renders correctly on GitHub

Made with [Cursor](https://cursor.com)