### PR TITLE
Declare JAX dependencies for ordinal regression notebook

### DIFF
--- a/examples/generalized_linear_models/GLM-ordinal-regression.ipynb
+++ b/examples/generalized_linear_models/GLM-ordinal-regression.ipynb
@@ -3891,6 +3891,11 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.9.16"
+  },
+  "myst": {
+   "substitutions": {
+    "extra_dependencies": "jax, jaxlib, numpyro"
+   }
   }
  },
  "nbformat": 4,

--- a/examples/generalized_linear_models/GLM-ordinal-regression.myst.md
+++ b/examples/generalized_linear_models/GLM-ordinal-regression.myst.md
@@ -8,6 +8,9 @@ kernelspec:
   display_name: pymc_examples_new
   language: python
   name: python3
+myst:
+  substitutions:
+    extra_dependencies: jax, jaxlib, numpyro
 ---
 
 (ordinal_regression)=


### PR DESCRIPTION
# Declare JAX dependencies for ordinal regression notebook

Fixes #548.

The ordinal regression notebook samples with NumPyro but did not declare the optional packages required to run those cells. This adds the same `myst.substitutions.extra_dependencies` metadata used by other NumPyro-based examples and keeps the paired MyST file synchronized.

## Validation

- `pre-commit run --files examples/generalized_linear_models/GLM-ordinal-regression.ipynb examples/generalized_linear_models/GLM-ordinal-regression.myst.md` (all hooks passed)

<!-- Thank you so much for your PR to pymc-examples!

To make the merge process smoother we've provided some links and a checklist below.

We understand that PRs can sometimes be overwhelming, especially as the reviews start coming in.
Please let us know if the reviews are unclear or the recommended next step seems overly demanding,
if you would like help in addressing a reviewer's comments,
or if you have been waiting too long to hear back on your PR. -->

+ [x] Notebook follows style guide https://docs.pymc.io/en/latest/contributing/jupyter_style.html
+ [x] PR description contains a link to the relevant issue:
  * a tracker one for existing notebooks (tracker issues have the "tracker id" label)
  * or a proposal one for new notebooks
+ [x] Check the notebook is not excluded from any pre-commit check: https://github.com/pymc-devs/pymc-examples/blob/main/.pre-commit-config.yaml


### Helpful links
* https://github.com/pymc-devs/pymc-examples/blob/main/CONTRIBUTING.md
